### PR TITLE
add the missing querystring of the URL

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -110,7 +110,7 @@ http_nodogsplash_first_contact(request *r)
 	t_client *client;
 	t_auth_target *authtarget;
 	s_config *config;
-	char *redir;
+	char *redir, *origurl;
 
 	/* only allow GET requests */
 	if (r->request.method != HTTP_GET) {
@@ -123,11 +123,20 @@ http_nodogsplash_first_contact(request *r)
 	/* http_nodogsplash_add_client() should log and return null on error */
 	if(!client) return;
 
+	/* We just assume protocol http; after all we caught the client by
+	   redirecting port 80 tcp packets
+	*/
+	safe_asprintf(&origurl,"http://%s%s%s%s",
+			r->request.host,r->request.path,
+			r->request.query[0]?"?":"",r->request.query);
+
 	/* Create redirect URL for this contact as appropriate */
-	redir = http_nodogsplash_make_redir(r->request.host,r->request.path);
+	redir = http_nodogsplash_make_redir(origurl);
+
 	/* Create authtarget with all needed info */
 	authtarget = http_nodogsplash_make_authtarget(client->token,redir);
-	free(redir);
+
+	free(origurl);
 
 	if(config->authenticate_immediately) {
 		/* Don't serve splash, just authenticate */
@@ -494,23 +503,16 @@ http_nodogsplash_decode_authtarget(request *r)
  * Caller must free.
  */
 char*
-http_nodogsplash_make_redir(char* redirhost, char* redirpath)
+http_nodogsplash_make_redir(char* origurl)
 {
 	s_config *config;
-	char* redir;
 	config = config_get_config();
 
 	if(config->redirectURL) {
-		debug(LOG_DEBUG,"Redirect request http://%s%s, substituting %s",
-			  redirhost,redirpath,config->redirectURL);
-		redir = safe_strdup(config->redirectURL);
-	} else {
-		/* We just assume protocol http; after all we caught the client by
-		   redirecting port 80 tcp packets
-		*/
-		safe_asprintf(&redir,"http://%s%s",redirhost,redirpath);
+		debug(LOG_DEBUG,"Redirect request , substituting %s", origurl);
+		return config->redirectURL;
 	}
-	return redir;
+	return origurl;
 }
 
 /**

--- a/src/http.h
+++ b/src/http.h
@@ -80,7 +80,7 @@ t_auth_target* http_nodogsplash_make_authtarget(char* token, char* redir);
 /**@brief Free a t_auth_target struct */
 void http_nodogsplash_free_authtarget(t_auth_target* authtarget);
 /**@brief Malloc and return a redirect URL */
-char* http_nodogsplash_make_redir(char* redirhost, char* redirpath);
+char* http_nodogsplash_make_redir(char* origurl);
 /**@brief Do password check if configured */
 int http_nodogsplash_check_password(request *r, t_auth_target *authtarget);
 /**@brief Allocate and return a random string of 8 hex digits


### PR DESCRIPTION
For the current version, the query string is missing in splash page.
This bug was induced by the commit ca80cbb, which contains only some
part of patch form wifidog: http://dev.wifidog.org/changeset/1239 .
