### PR TITLE
Send HTTP 302 instead of 307

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ replaced by their values:
 * $authtarget A URL which encodes a unique token and the URL of the user's
   original web request. If nodogsplash receives a request at this URL, it
   completes the authentication process for the client and replies to the
-  request with a "307 Temporary Redirect" to the encoded originally requested
+  request with a "302 Found" to the encoded originally requested
   URL. (Alternatively, you can use a GET-method HTML form to send this
   information to the nodogsplash server; see below.) As a simple example:
 

--- a/src/http.c
+++ b/src/http.c
@@ -590,7 +590,7 @@ http_nodogsplash_redirect(request *r, char *url)
 {
 	char *header;
 
-	httpdSetResponse(r, "307 Temporary Redirect");
+	httpdSetResponse(r, "302 Found");
 	safe_asprintf(&header, "Location: %s",url);
 	httpdAddHeader(r, header);
 

--- a/src/http.h
+++ b/src/http.h
@@ -64,7 +64,7 @@ void http_nodogsplash_callback_deny(httpd *webserver, request *r);
 void http_nodogsplash_callback_action(request *r, t_auth_target *authtarget, t_authaction action);
 /**@brief Add client identified in request to client list. */
 t_client* http_nodogsplash_add_client(request *r);
-/**@brief Serve a 307 Temporary Redirect */
+/**@brief Serve a 302 Found */
 void http_nodogsplash_redirect(request *r, char *url);
 /**@brief Redirect to remote auth server */
 void http_nodogsplash_redirect_remote_auth(request *r, t_auth_target *authtarget);


### PR DESCRIPTION
We are speking HTTP/1.0, so 307 doesn't exist

Signed-off-by: Etienne CHAMPETIER etienne.champetier@free.fr

This can sometimes cause problem:
http://dev.wifidog.org/ticket/848

Also 307 mean if i was doing a POST, do a POST on the new location (the splash)
What we really want is 303, but it's HTTP/1.1
see also http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3
