### PR TITLE
add gatewaymac variable to splash page

### DIFF
--- a/resources/splash.html
+++ b/resources/splash.html
@@ -27,6 +27,7 @@
 	authtarget: $authtarget
 	clientip: $clientip
 	clientmac: $clientmac
+	gatewaymac: $gatewaymac
 	nclients: $nclients
 	maxclients: $maxclients
 	uptime: $uptime

--- a/src/conf.h
+++ b/src/conf.h
@@ -149,6 +149,7 @@ typedef struct {
 	char *gw_interface;		/**< @brief Interface we will manage */
 	char *gw_iprange;		/**< @brief IP range on gw_interface we will manage */
 	char *gw_address;		/**< @brief Internal IP address for our web server */
+	char *gw_mac;		/**< @brief MAC address of the interface we manage */
 	unsigned int gw_port;		/**< @brief Port the webserver will run on */
 	char *remote_auth_action;	/**< @brief Path for remote auth */
 	char enable_preauth;    /**< @brief enable pre-authentication support */

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -234,7 +234,11 @@ main_loop(void)
 			debug(LOG_ERR, "Could not get IP address information of %s, exiting...", config->gw_interface);
 			exit(1);
 		}
-		debug(LOG_NOTICE, "Detected gateway %s at %s", config->gw_interface, config->gw_address);
+		if ((config->gw_mac = get_iface_mac(config->gw_interface)) == NULL) {
+			debug(LOG_ERR, "Could not get MAC address information of %s, exiting...", config->gw_interface);
+			exit(1);
+		}
+		debug(LOG_NOTICE, "Detected gateway %s at %s (%s)", config->gw_interface, config->gw_address, config->gw_mac);
 	}
 
 	/* Initializes the web server */

--- a/src/http.c
+++ b/src/http.c
@@ -491,6 +491,7 @@ http_nodogsplash_serve_splash(request *r, t_auth_target *authtarget, t_client *c
 	httpdAddVariable(r,"authtarget",authtarget->authtarget);
 	httpdAddVariable(r,"clientip",client->ip);
 	httpdAddVariable(r,"clientmac",client->mac);
+	httpdAddVariable(r,"gatewaymac",config->gw_mac);
 	safe_asprintf(&tmpstr, "%d", get_client_list_length());
 	httpdAddVariable(r,"nclients",tmpstr);
 	free(tmpstr);


### PR DESCRIPTION
Make the MAC address of the managed gateway interface available as $gatewaymac variable in the splash page..
