### PR TITLE
Turn nodogsplash back to multi-thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDLIBS=
 
 NDS_OBJS=src/auth.o src/client_list.o src/commandline.o src/conf.o \
 	src/debug.o src/firewall.o src/fw_iptables.o src/gateway.o src/http.o \
-	src/httpd_handler.o src/ndsctl_thread.o src/safe.o src/tc.o src/util.o
+	src/httpd_thread.o src/ndsctl_thread.o src/safe.o src/tc.o src/util.o
 
 LIBHTTPD_OBJS=libhttpd/api.o libhttpd/ip_acl.o \
 	libhttpd/protocol.o libhttpd/version.o

--- a/libhttpd/api.c
+++ b/libhttpd/api.c
@@ -74,16 +74,12 @@ char *httpdUrlEncode(str)
 
 char *httpdRequestMethodName(request *r)
 {
-	static	char	tmpBuf[255];
-
 	switch(r->request.method)
 	{
 		case HTTP_GET: return("GET");
 		case HTTP_POST: return("POST");
 		default:
-			snprintf(tmpBuf,255,"Invalid method '%d'",
-				r->request.method);
-			return(tmpBuf);
+			return("INVALID");
 	}
 }
 
@@ -377,7 +373,7 @@ request *httpdGetConnection(server, timeout)
 
 int httpdReadRequest(httpd *server, request *r)
 {
-	static	char	buf[HTTP_MAX_LEN];
+	char	buf[HTTP_MAX_LEN];
 	int	count,
 		inHeaders;
 	char	*cp, *cp2;

--- a/src/conf.c
+++ b/src/conf.c
@@ -101,6 +101,9 @@ typedef enum {
 	oDownloadIMQ,
 	oUploadIMQ,
 	oNdsctlSocket,
+	oDecongestHttpdThreads,
+	oHttpdThreadThreshold,
+	oHttpdThreadDelayMS,
 	oSyslogFacility,
 	oFirewallRule,
 	oFirewallRuleSet,
@@ -158,6 +161,9 @@ static const struct {
 	{ "syslogfacility", oSyslogFacility },
 	{ "syslogfacility", oSyslogFacility },
 	{ "ndsctlsocket", oNdsctlSocket },
+	{ "decongesthttpdthreads", oDecongestHttpdThreads },
+	{ "httpdthreadthreshold", oHttpdThreadThreshold },
+	{ "httpdthreaddelayms", oHttpdThreadDelayMS },
 	{ "firewallruleset", oFirewallRuleSet },
 	{ "firewallrule", oFirewallRule },
 	{ "emptyrulesetpolicy", oEmptyRuleSetPolicy },
@@ -239,6 +245,9 @@ config_init(void)
 	config.log_syslog = DEFAULT_LOG_SYSLOG;
 	config.ndsctl_sock = safe_strdup(DEFAULT_NDSCTL_SOCK);
 	config.internal_sock = safe_strdup(DEFAULT_INTERNAL_SOCK);
+	config.decongest_httpd_threads = DEFAULT_DECONGEST_HTTPD_THREADS;
+	config.httpd_thread_threshold = DEFAULT_HTTPD_THREAD_THRESHOLD;
+	config.httpd_thread_delay_ms = DEFAULT_HTTPD_THREAD_DELAY_MS;
 	config.rulesets = NULL;
 	config.trustedmaclist = NULL;
 	config.blockedmaclist = NULL;
@@ -803,6 +812,29 @@ config_read(const char *filename)
 		case oNdsctlSocket:
 			free(config.ndsctl_sock);
 			config.ndsctl_sock = safe_strdup(p1);
+			break;
+		case oDecongestHttpdThreads:
+			if ((value = parse_boolean_value(p1)) != -1) {
+				config.decongest_httpd_threads = value;
+			} else {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(-1);
+			}
+			break;
+		case oHttpdThreadThreshold:
+			if(sscanf(p1, "%d", &config.httpd_thread_threshold) < 1) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(-1);
+			}
+			break;
+		case oHttpdThreadDelayMS:
+			if(sscanf(p1, "%d", &config.httpd_thread_delay_ms) < 1) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(-1);
+			}
 			break;
 		case oClientIdleTimeout:
 			if(sscanf(p1, "%d", &config.clienttimeout) < 1) {

--- a/src/conf.h
+++ b/src/conf.h
@@ -83,6 +83,9 @@
 #define DEFAULT_FW_MARK_AUTHENTICATED 0x400
 #define DEFAULT_FW_MARK_TRUSTED 0x200
 #define DEFAULT_FW_MARK_BLOCKED 0x100
+#define DEFAULT_DECONGEST_HTTPD_THREADS 0
+#define DEFAULT_HTTPD_THREAD_THRESHOLD 3
+#define DEFAULT_HTTPD_THREAD_DELAY_MS 200
 /* N.B.: default policies here must be ACCEPT, REJECT, or RETURN
  * In the .conf file, they must be allow, block, or passthrough
  * Mapping between these enforced by parse_empty_ruleset_policy() */
@@ -183,6 +186,9 @@ typedef struct {
 	int upload_imq;		/**< @brief Number of IMQ handling upload */
 	int log_syslog;		/**< @brief boolean, whether to log to syslog */
 	int syslog_facility;		/**< @brief facility to use when using syslog for logging */
+	int decongest_httpd_threads;	/**< @brief boolean, whether to avoid httpd thread congestion */
+	int httpd_thread_threshold; 	/**< @brief number of concurrent httpd threads before trying decongestion */
+	int httpd_thread_delay_ms; /**< @brief ms delay before starting a httpd thread after threshold */
 	int macmechanism; 		/**< @brief mechanism wrt MAC addrs */
 	t_firewall_ruleset *rulesets;	/**< @brief firewall rules */
 	t_MAC *trustedmaclist; 	/**< @brief list of trusted macs */

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -57,7 +57,7 @@
 #include "http.h"
 #include "client_list.h"
 #include "ndsctl_thread.h"
-#include "httpd_handler.h"
+#include "httpd_thread.h"
 #include "util.h"
 
 
@@ -72,6 +72,11 @@ httpd * webserver = NULL;
 
 /* Time when nodogsplash started  */
 time_t started_time = 0;
+
+/* Total number of httpd request handling threads started */
+int created_httpd_threads;
+/* Number of current httpd request handling threads */
+int current_httpd_threads;
 
 
 /**@internal
@@ -296,6 +301,8 @@ main_loop(void)
 	 * Enter the httpd request handling loop
 	 */
 	debug(LOG_NOTICE, "Waiting for connections");
+	created_httpd_threads = 0;
+	current_httpd_threads = 0;
 	while(1) {
 		r = httpdGetConnection(webserver, NULL);
 
@@ -313,8 +320,37 @@ main_loop(void)
 			debug(LOG_ERR, "FATAL: httpdGetConnection returned unexpected value %d, exiting.", webserver->lastError);
 			termination_handler(0);
 		} else if (r != NULL) {
-			/* We got a connection */
-			handle_http_request(webserver, r);
+			/*
+			 * We got a connection
+			 *
+			 * We create another thread to handle the request,
+			 * possibly sleeping first if there are too many already
+			 */
+			debug(LOG_DEBUG,"%d current httpd threads.", current_httpd_threads);
+			if(config->decongest_httpd_threads && current_httpd_threads >= config->httpd_thread_threshold) {
+				msec = current_httpd_threads * config->httpd_thread_delay_ms;
+				wait_time.tv_sec = msec / 1000;
+				wait_time.tv_nsec = (msec % 1000) * 1000000;
+				debug(LOG_INFO, "Httpd thread creation delayed %ld sec %ld nanosec for congestion.",
+					  wait_time.tv_sec, wait_time.tv_nsec);
+				nanosleep(&wait_time,NULL);
+			}
+			thread_serial_num_p = (int*) malloc(sizeof(int)); /* thread_httpd() must free */
+			*thread_serial_num_p = created_httpd_threads;
+			debug(LOG_INFO, "Creating httpd request thread %d for %s", *thread_serial_num_p, r->clientAddr);
+			/* The void**'s are a simulation of the normal C
+			 * function calling sequence. */
+			params = safe_malloc(3 * sizeof(void *)); /* thread_httpd() must free */
+			*params = webserver;
+			*(params + 1) = r;
+			*(params + 2) = thread_serial_num_p;
+			created_httpd_threads++;
+			result = pthread_create(&tid, NULL, (void *)thread_httpd, (void *)params);
+			if (result != 0) {
+				debug(LOG_ERR, "FATAL: pthread_create failed to create httpd request thread - exiting...");
+				termination_handler(0);
+			}
+			pthread_detach(tid);
 		} else {
 			/* webserver->lastError should be 2 */
 			/* XXX We failed an ACL.... No handling because

--- a/src/httpd_thread.c
+++ b/src/httpd_thread.c
@@ -66,7 +66,7 @@ thread_httpd(void *args)
 	params = (void **)args;
 	webserver = *params;
 	r = *(params + 1);
-	serialnum = *(params + 2);
+	serialnum = *((int *)*(params + 2));
 	free(*(params + 2)); /* XXX We must release this here. */
 	free(params); /* XXX We must release this here. */
 

--- a/src/httpd_thread.c
+++ b/src/httpd_thread.c
@@ -44,6 +44,7 @@
 
 
 /* Defined in gateway.c */
+extern pthread_mutex_t httpd_mutex;
 extern int created_httpd_threads;
 extern int current_httpd_threads;
 
@@ -58,7 +59,9 @@ thread_httpd(void *args)
 	request *r;
 	int serialnum;
 
+	pthread_mutex_lock(&httpd_mutex);
 	current_httpd_threads++;
+	pthread_mutex_unlock(&httpd_mutex);
 
 	params = (void **)args;
 	webserver = *params;
@@ -80,5 +83,7 @@ thread_httpd(void *args)
 	httpdEndRequest(r);
 	debug(LOG_DEBUG, "Thread %d ended request from %s", serialnum, r->clientAddr);
 
+	pthread_mutex_lock(&httpd_mutex);
 	current_httpd_threads--;
+	pthread_mutex_unlock(&httpd_mutex);
 }

--- a/src/httpd_thread.c
+++ b/src/httpd_thread.c
@@ -18,9 +18,9 @@
  *                                                                  *
 \********************************************************************/
 
-/* $Id: httpd_handler.c 901 2006-01-17 18:58:13Z mina $ */
+/* $Id: httpd_thread.c 901 2006-01-17 18:58:13Z mina $ */
 
-/** @file httpd_handler.c
+/** @file httpd_thread.c
     @brief Handles one web request.
     @author Copyright (C) 2004 Alexandre Carmel-Veilleux <acv@acv.ca>
 */
@@ -29,6 +29,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <pthread.h>
 #include <string.h>
 #include <unistd.h>
 #include <syslog.h>
@@ -39,25 +40,45 @@
 
 #include "common.h"
 #include "debug.h"
-#include "httpd_handler.h"
+#include "httpd_thread.h"
 
 
-/** Entry point for httpd request handler.
+/* Defined in gateway.c */
+extern int created_httpd_threads;
+extern int current_httpd_threads;
+
+/** Entry point for httpd request handling thread.
 @param args Two item array of void-cast pointers to the httpd and request struct
 */
 void
-handle_http_request(httpd *webserver, request *r)
+thread_httpd(void *args)
 {
+	void **params;
+	httpd *webserver;
+	request *r;
+	int serialnum;
+
+	current_httpd_threads++;
+
+	params = (void **)args;
+	webserver = *params;
+	r = *(params + 1);
+	serialnum = *(params + 2);
+	free(*(params + 2)); /* XXX We must release this here. */
+	free(params); /* XXX We must release this here. */
+
 	if (httpdReadRequest(webserver, r) == 0) {
 		/*
 		 * We read the request fine
 		 */
-		debug(LOG_DEBUG, "Calling httpdProcessRequest() for %s", r->clientAddr);
+		debug(LOG_DEBUG, "Thread %d calling httpdProcessRequest() for %s", serialnum, r->clientAddr);
 		httpdProcessRequest(webserver, r);
-		debug(LOG_DEBUG, "Returned from httpdProcessRequest() for %s", r->clientAddr);
+		debug(LOG_DEBUG, "Thread %d returned from httpdProcessRequest() for %s", serialnum, r->clientAddr);
 	} else {
-		debug(LOG_DEBUG, "No valid request received from %s", r->clientAddr);
+		debug(LOG_DEBUG, "Thread %d: No valid request received from %s", serialnum, r->clientAddr);
 	}
 	httpdEndRequest(r);
-	debug(LOG_DEBUG, "Ended request from %s", r->clientAddr);
+	debug(LOG_DEBUG, "Thread %d ended request from %s", serialnum, r->clientAddr);
+
+	current_httpd_threads--;
 }

--- a/src/httpd_thread.h
+++ b/src/httpd_thread.h
@@ -18,18 +18,18 @@
  *                                                                  *
 \********************************************************************/
 
-/* $Id: httpd_handler.h 901 2006-01-17 18:58:13Z mina $ */
-/** @file httpd_handler.h
-    @brief nodogsplash httpd worker handler
+/* $Id: httpd_thread.h 901 2006-01-17 18:58:13Z mina $ */
+/** @file httpd_thread.h
+    @brief nodogsplash httpd worker thread
     @author Copyright (C) 2004 Alexandre Carmel-Veilleux <acv@acv.ca>
 */
 
-#ifndef _HTTPD_HANDLER_H_
-#define _HTTPD_HANDLER_H_
+#ifndef _HTTPD_THREAD_H_
+#define _HTTPD_THREAD_H_
 
 
 /** @brief Handle a web request */
-void handle_http_request(httpd *webserver, request *r);
+void thread_httpd(void *args);
 
 
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -81,6 +81,10 @@ extern	pthread_mutex_t	config_mutex;
 /* Defined in auth.c */
 extern unsigned int authenticated_since_start;
 
+/* Defined in gateway.c */
+extern int created_httpd_threads;
+extern int current_httpd_threads;
+
 
 /** Fork a child and execute a shell command.
  * The parent process waits for the child to return,
@@ -501,6 +505,16 @@ char * get_status_text()
 
 	snprintf((buffer + len), (sizeof(buffer) - len), "Client authentications since start: %lu\n", authenticated_since_start);
 	len = strlen(buffer);
+
+	snprintf((buffer + len), (sizeof(buffer) - len), "Httpd request threads created/current: %d/%d\n", created_httpd_threads, current_httpd_threads);
+	len = strlen(buffer);
+
+	if(config->decongest_httpd_threads) {
+		snprintf((buffer + len), (sizeof(buffer) - len), "Httpd thread decongest threshold: %d threads\n", config->httpd_thread_threshold);
+		len = strlen(buffer);
+		snprintf((buffer + len), (sizeof(buffer) - len), "Httpd thread decongest delay: %d ms\n", config->httpd_thread_delay_ms);
+		len = strlen(buffer);
+	}
 
 	/* Update the client's counters so info is current */
 	iptables_fw_counters_update();


### PR DESCRIPTION
This pull request should solve the problem of Issue #30.

I've just reverted the commit of Issue #9 without any conflict.
Then, solve the race conditions by turning static variables into local variables.