### PR TITLE
I add a comma symbol in a sentence which is in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ In the configuration file, a FirewallRule has the form:
 where
 
 * *permission* is required and must be allow, block, drop, log, or ulog.
-* *protocol* is optional. If present must be tcp, udp, icmp, or all.
+* *protocol* is optional. If present, it must be tcp, udp, icmp, or all.
   Defaults to all.
 * port *portrange* is optional. If present, protocol must be tcp or udp.
   portrange can be a single integer port number, or a colon-separated port


### PR DESCRIPTION
protocol is optional. If present, it must be tcp, udp, icmp, or all.
