### PR TITLE
Renewed Debian packaging instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LIBHTTPD_OBJS=libhttpd/api.o libhttpd/ip_acl.o \
 all: nodogsplash ndsctl
 
 %.o : %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 nodogsplash: $(NDS_OBJS) $(LIBHTTPD_OBJS)
 	$(CC) $(LDFLAGS) -o nodogsplash $+ $(LDLIBS)

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ nodogsplash (0.9-beta9.9.9-2) unstable; urgency=low
     - policy bump to 3.9.6
     - added hardening
     - some extra work on the description
-  * Added Markus Warning and Steffen Moeller to uploaders
+  * Added Moritz Warning and Steffen Moeller to uploaders
 
  -- Steffen Moeller <moeller@debian.org>  Fri, 26 Dec 2014 16:21:48 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+nodogsplash (0.9-beta9.9.9-2) unstable; urgency=low
+
+  * Improved Debian packaging
+    - policy bump to 3.9.6
+    - added hardening
+    - some extra work on the description
+  * Added Markus Warning and Steffen Moeller to uploaders
+
+ -- Steffen Moeller <moeller@debian.org>  Fri, 26 Dec 2014 16:21:48 +0100
+
 nodogsplash (0.9-beta9.9.9-1) unstable; urgency=low
 
   * fix regression introduced by BinVoucher feature,

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Shiao-An Yuan <shiao.an.yuan@gmail.com>
 Uploaders: Moritz Warning <moritzwarning@web.de>, Steffen Moeller <moeller@debian.org>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), dpkg-dev (>= 1.16.1~)
 Standards-Version: 3.9.6
 Homepage: http://kokoro.ucsd.edu/nodogsplash/
 Vcs-Git: git://github.com/nodogsplash/nodogsplash.git
@@ -13,10 +13,7 @@ Package: nodogsplash
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: manage access to public internet access
- Nodogsplash controlls access to a public internet connection, as it is
- e.g. commonly demanded for WiFi a HotSpot. It provides a captive portal
- to inform users about the services and optionally have them acknowledge
- the terms and conditions of its use.
- .
- The complexity of user account names, passwords and their maintenance
- is separated into a database-backed authentication server.
+ Nodogsplash controlls access to a public Internet connection and offers
+ a simple way to open a Hotspot for wireless networks.  It provides a
+ captive portal to inform users about the services and optionally have
+ them acknowledge the terms and conditions of its use.

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,9 @@ Source: nodogsplash
 Section: net
 Priority: optional
 Maintainer: Shiao-An Yuan <shiao.an.yuan@gmail.com>
+Uploaders: Moritz Warning <moritzwarning@web.de>, Steffen Moeller <moeller@debian.org>
 Build-Depends: debhelper (>= 8.0.0)
-Standards-Version: 3.9.2
+Standards-Version: 3.9.6
 Homepage: http://kokoro.ucsd.edu/nodogsplash/
 Vcs-Git: git://github.com/nodogsplash/nodogsplash.git
 Vcs-Browser: http://github.com/nodogsplash/nodogsplash
@@ -11,9 +12,11 @@ Vcs-Browser: http://github.com/nodogsplash/nodogsplash
 Package: nodogsplash
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Provide restricted access to an internet connection
- Nodogsplash offers a solution to this problem: You want to provide controlled
- and reasonably secure public access to an internet connection; and while you
- want to require users to give some acknowledgment of the service you are
- providing, you don't need or want the complexity of user account names and
- passwords and maintaining a separate database-backed authentication server.
+Description: manage access to public internet access
+ Nodogsplash controlls access to a public internet connection, as it is
+ e.g. commonly demanded for WiFi a HotSpot. It provides a captive portal
+ to inform users about the services and optionally have them acknowledge
+ the terms and conditions of its use.
+ .
+ The complexity of user account names, passwords and their maintenance
+ is separated into a database-backed authentication server.

--- a/debian/doc/nodogsplash.1
+++ b/debian/doc/nodogsplash.1
@@ -1,10 +1,10 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "README" "" "August 2013" "" ""
+.TH "NODOGSPLASH" 1 "August 2013" "The Nodogsplash Project" "User commands"
 .
 .SH "NAME"
-\fBREADME\fR
+Nogogsplash - suite to implement a captive portal for wireless networks
 .
 .SH "0\. The Nodogsplash project"
 Nodogsplash offers a simple way to provide restricted access to an internet connection\. It is derived from the codebase of the Wifi Guard Dog project\. Nodogsplash is released under the GNU General Public License\.

--- a/debian/links
+++ b/debian/links
@@ -1,0 +1,1 @@
+usr/share/man/man1/nodogsplash.1.gz usr/share/man/man1/ndsctl.1.gz

--- a/debian/rules
+++ b/debian/rules
@@ -1,14 +1,5 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-#
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
-#
-# Modified to make a template file for a multi-binary package with separated
-# build-arch and build-indep targets  by Bill Allombert 2001
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
@@ -16,6 +7,11 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+DPKG_EXPORT_BUILDFLAGS = 1
+include /usr/share/dpkg/buildflags.mk
+
+export CFLAGS += -flto
+export LDFLAGS += -flto
 
 %:
 	dh $@ 

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,7 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 


### PR DESCRIPTION
A series of preparations to see nodogsplash distributed with Debian - with auto-transitions to Ubuntu and other derivative distributions.

 * debian/control
  * policy version bump
  * partial rewrite of description
  * added Markus Warning and myself to uploaders
 * debian/rules
  * introduced hardening
  * link-time optimisation
 * debian/changelog