### PR TITLE
Automatically deauth preauthenticated users

### DIFF
--- a/src/firewall.c
+++ b/src/firewall.c
@@ -208,3 +208,7 @@ fw_connection_state_as_string(int mark)
 	return "ERROR: unrecognized mark";
 }
 
+/** automatically deauthorize preauthenticated users if not self-authenticated withing 5 minutes */
+else if (added_time + (config->checkinterval * 5 <= now && cp1->fw_connection_state == FW_MARK_PREAUTHENTICATED ) {
+client_list_delete(cp1);
+}


### PR DESCRIPTION
I have noticed many preauthorised users who for unknown reasons don't go through authorisation. The major issue with it is, if they try to go through authorisation they might encounter "invalid token" error. So I automatically deauthorize them completely.

Your input, feedback and corrections to code are highly appreciated :)
