### PR TITLE
Can we do something (resonable) about these compiler warnings?

### DIFF
--- a/src/ndsctl_thread.c
+++ b/src/ndsctl_thread.c
@@ -257,8 +257,8 @@ ndsctl_clients(int fd)
 	status = get_clients_text();
 	len = strlen(status);
 
-	write(fd, status, len);
-
+	/* e.g. here? */write(fd, status, len);
+	/* and here? */
 	free(status);
 }
 


### PR DESCRIPTION
Somehow these warnings don't feel right. I would not know what to do about them, though.

<pre>
cc -D_FORTIFY_SOURCE=2 -g -O2 -fPIE -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -flto -Isrc -Ilibhttpd -c src/httpd_thread.c -o src/httpd_thread.o
cc -D_FORTIFY_SOURCE=2 -g -O2 -fPIE -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -flto -Isrc -Ilibhttpd -c src/ndsctl_thread.c -o src/ndsctl_thread.o
src/ndsctl_thread.c: In function 'ndsctl_status':
src/ndsctl_thread.c:246:7: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_clients':
src/ndsctl_thread.c:260:7: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_block':
src/ndsctl_thread.c:352:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:354:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_unblock':
src/ndsctl_thread.c:371:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:373:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_allow':
src/ndsctl_thread.c:390:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:392:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_unallow':
src/ndsctl_thread.c:409:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:411:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_trust':
src/ndsctl_thread.c:428:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:430:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_untrust':
src/ndsctl_thread.c:447:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:449:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_auth':
src/ndsctl_thread.c:290:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:303:7: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_deauth':
src/ndsctl_thread.c:325:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:338:7: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_loglevel':
src/ndsctl_thread.c:469:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:472:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_password':
src/ndsctl_thread.c:490:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:493:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c: In function 'ndsctl_username':
src/ndsctl_thread.c:511:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
src/ndsctl_thread.c:514:8: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
</pre>
