### PR TITLE
fix segfault in httpd_thread.c under high load

### DIFF
--- a/src/httpd_thread.c
+++ b/src/httpd_thread.c
@@ -80,8 +80,8 @@ thread_httpd(void *args)
 	} else {
 		debug(LOG_DEBUG, "Thread %d: No valid request received from %s", serialnum, r->clientAddr);
 	}
-	httpdEndRequest(r);
 	debug(LOG_DEBUG, "Thread %d ended request from %s", serialnum, r->clientAddr);
+	httpdEndRequest(r);
 
 	pthread_mutex_lock(&httpd_mutex);
 	current_httpd_threads--;


### PR DESCRIPTION
This segfault occures if: no daemon mode AND debuglevel 7 AND high load server with *httperf --hog --server=IP --port=2050 --wsess=100,10,0.01 --rate=100 --timeout=5* AND GDB not used.

This error fixed if *httpdEndRequest(r)* in *thread_httpd(void *args)* placed after debug message which use request *r->clientAddr*