### PR TITLE
Add 'ndsctl json' option

### DIFF
--- a/src/ndsctl.c
+++ b/src/ndsctl.c
@@ -54,6 +54,7 @@ static void ndsctl_action(const char[], const char[], const char[]);
 static void ndsctl_print(const char[]);
 static void ndsctl_status(void);
 static void ndsctl_clients(void);
+static void ndsctl_json(void);
 static void ndsctl_stop(void);
 static void ndsctl_block(void);
 static void ndsctl_unblock(void);
@@ -84,6 +85,7 @@ usage(void)
 	printf("commands:\n");
 	printf("  status              View the status of nodogsplash\n");
 	printf("  clients             Display machine-readable client list\n");
+	printf("  json             	  Display machine-readable client list in json format\n");
 	printf("  stop                Stop the running nodogsplash\n");
 	printf("  auth mac|ip|token   Authenticate user with specified mac, ip or token\n");
 	printf("  deauth mac|ip|token Deauthenticate user with specified mac, ip or token\n");
@@ -150,6 +152,8 @@ parse_commandline(int argc, char **argv)
 		config.command = NDSCTL_STATUS;
 	} else if (strcmp(*(argv + optind), "clients") == 0) {
 		config.command = NDSCTL_CLIENTS;
+	} else if (strcmp(*(argv + optind), "json") == 0) {
+		config.command = NDSCTL_JSON;
 	}
 
 	else if (strcmp(*(argv + optind), "stop") == 0) {
@@ -381,6 +385,12 @@ ndsctl_clients(void)
 }
 
 static void
+ndsctl_json(void)
+{
+	ndsctl_print("json");
+}
+
+static void
 ndsctl_status(void)
 {
 	ndsctl_print("status");
@@ -494,6 +504,10 @@ main(int argc, char **argv)
 
 	case NDSCTL_CLIENTS:
 		ndsctl_clients();
+		break;
+
+	case NDSCTL_JSON:
+		ndsctl_json();
 		break;
 
 	case NDSCTL_STOP:

--- a/src/ndsctl.h
+++ b/src/ndsctl.h
@@ -49,6 +49,7 @@
 #define NDSCTL_PASSWORD		14
 #define NDSCTL_USERNAME		15
 #define NDSCTL_CLIENTS 		16
+#define NDSCTL_JSON 		17
 
 
 typedef struct {

--- a/src/ndsctl_thread.c
+++ b/src/ndsctl_thread.c
@@ -61,6 +61,7 @@ extern	pthread_mutex_t	config_mutex;
 static void *thread_ndsctl_handler(void *);
 static void ndsctl_status(int);
 static void ndsctl_clients(int);
+static void ndsctl_json(int);
 static void ndsctl_stop(int);
 static void ndsctl_block(int, char *);
 static void ndsctl_unblock(int, char *);
@@ -192,6 +193,8 @@ thread_ndsctl_handler(void *arg)
 		ndsctl_status(fd);
 	} else if (strncmp(request, "clients", 7) == 0) {
 		ndsctl_clients(fd);
+	} else if (strncmp(request, "json", 4) == 0) {
+		ndsctl_json(fd);
 	} else if (strncmp(request, "stop", 4) == 0) {
 		ndsctl_stop(fd);
 	} else if (strncmp(request, "block", 5) == 0) {
@@ -255,6 +258,20 @@ ndsctl_clients(int fd)
 	int len = 0;
 
 	status = get_clients_text();
+	len = strlen(status);
+
+	write(fd, status, len);
+
+	free(status);
+}
+
+static void
+ndsctl_json(int fd)
+{
+	char * status = NULL;
+	int len = 0;
+
+	status = get_clients_json();
 	len = strlen(status);
 
 	write(fd, status, len);

--- a/src/util.h
+++ b/src/util.h
@@ -69,6 +69,10 @@ char *get_status_text();
  * @brief Creates a machine-readable dump of currently connected clients
  */
 char *get_clients_text();
+/*
+ * @brief Creates a machine-readable json of currently connected clients
+ */
+char *get_clients_json();
 
 /** @brief cheap random */
 unsigned short rand16(void);


### PR DESCRIPTION
Sample output:
===================

```javascript
# ndsctl json
{
	"client_length": 2,
	"clients": {
		"2f:82:71:b4:23:3f": {
			"client_id": 0,
			"ip": "10.10.10.115",
			"mac": "2c:8a:72:b4:23:1f",
			"added": 1464536854,
			"active": 1464536854,
			"duration": 107,
			"token": "cc6cb718",
			"state": "Preauthenticated",
			"downloaded": "0",
			"avg_down_speed": "0",
			"uploaded": "0",
			"avg_up_speed": "0"
		},
		"64:a8:50:da:eb:95": {
			"client_id": 1,
			"ip": "10.10.10.125",
			"mac": "64:b8:53:da:eb:95",
			"added": 1464536959,
			"active": 1464536959,
			"duration": 2,
			"token": "3b45fdfb",
			"state": "Preauthenticated",
			"downloaded": "0",
			"avg_down_speed": "0",
			"uploaded": "0",
			"avg_up_speed": "0"
		}
	}
}
```