### PR TITLE
deauthenticate preauth clients

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,8 +28,6 @@ nodogsplash (0.9-beta9.9.9)
     traffic was not blocked except on port 80 [mwarning]
   * make returned upload/download value by BinVoucher script
     optional, as stated in the documentation [mwarning]
-  * make variables clientmac and gatewaymac
-    available in the splash page [mwarning]
 
  -- Moritz Warning <moritzwarning@web.de>  Sun, 15 Jun 2014 22:55:12 +0200
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+nodogsplash (1.0.2)
+
+  * fix iptables syntax for 1.6.1 [ghost]
+  * small allocation optimization [mwarning]
+  * fix compilation for musl libc [jow]
+
+ --  <mwarning@xanax>  Mon, 15 May 2017 23:21:16 +0200
 
 nodogsplash (1.0.1)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ nodogsplash (1.0.1)
 
   * Set version in source code to 1.0.1 [mwarning]
   * Add 'ndsctl json' option [gazambuja]
+  * Fix possible division by zero and negative durations [mwarning]
 
  -- Moritz Warning <moritzwarning@web.de> Thu, 28 Jul 2016 18:13:01 -0400
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,11 @@
 
+nodogsplash (1.0.1)
+
+  * Set version in source code to 1.0.1 [mwarning]
+  * Add 'ndsctl json' option [gazambuja]
+
+ -- Moritz Warning <moritzwarning@web.de> Thu, 28 Jul 2016 18:13:01 -0400
+
 nodogsplash (1.0.0)
 
   * make "ndsctl auth/deauth" work with tokens [vavrecan]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ mangle PREROUTING and POSTROUTING tables to jump to these IMQ's. The result is
 simple but effective tail-drop rate limiting (no packet classification or
 fairness queueing is done).
 
+Note: IMQ is not included anymore by OpenWrt Attitude Adjustment (12.09).
+
 ##4. Customizing nodogsplash
 
 The default shipped configuration is intended to be usable and reasonably

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+nodogsplash (1.0.2-1) stable; urgency=medium
+
+  * fix iptables syntax for 1.6.1 [ghost]
+  * small allocation optimization [mwarning]
+  * fix compilation for musl libc [jow]
+
+ --  <mwarning@xanax>  Mon, 15 May 2017 23:21:16 +0200
+
 nodogsplash (1.0.1-1) stable; urgency=low
 
   * Set version in source code to 1.0.1 [mwarning]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nodogsplash (1.0.1-1) stable; urgency=low
+
+  * Set version in source code to 1.0.1 [mwarning]
+  * Add 'ndsctl json' option [gazambuja]
+
+ -- Moritz Warning <moritzwarning@web.de> Thu, 28 Jul 2016 18:13:01 -0400
+
 nodogsplash (1.0.0-1) stable; urgency=low
 
   * make "ndsctl auth/deauth" work with tokens [vavrecan]

--- a/libhttpd/protocol.c
+++ b/libhttpd/protocol.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <fcntl.h>
 
 #if defined(_WIN32) 
 #else

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -36,7 +36,7 @@
 #include <pthread.h>
 #include <sys/wait.h>
 #include <sys/types.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 #include <string.h>
 

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -211,8 +211,7 @@ client_list_add_client(const char ip[])
 		client = _client_list_append(ip, mac, token);
 		free(token);
 	} else {
-		debug(LOG_INFO, "Client %s %s token %s already on client list",
-			  ip, mac, client->token);
+		debug(LOG_INFO, "Client %s %s token %s already on client list", ip, mac, client->token);
 	}
 	free(mac);
 	return client;

--- a/src/conf.h
+++ b/src/conf.h
@@ -28,7 +28,7 @@
 #ifndef _CONF_H_
 #define _CONF_H_
 
-#define VERSION "1.0.1"
+#define VERSION "1.0.2"
 
 /*@{*/
 /** Defines */

--- a/src/conf.h
+++ b/src/conf.h
@@ -28,7 +28,7 @@
 #ifndef _CONF_H_
 #define _CONF_H_
 
-#define VERSION "0.9_beta9.9.9"
+#define VERSION "1.0.1"
 
 /*@{*/
 /** Defines */

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -169,8 +169,8 @@ fw_refresh_client_list(void)
 			if (last_updated +  (config->checkinterval * config->clienttimeout) <= now) {
 				/* Timing out inactive user */
 				debug(LOG_NOTICE, "%s %s inactive %d secs. kB in: %llu  kB out: %llu",
-					cp1->ip, cp1->mac, config->checkinterval * config->clienttimeout,
-					cp1->counters.incoming/1000, cp1->counters.outgoing/1000);
+					  cp1->ip, cp1->mac, config->checkinterval * config->clienttimeout,
+					  cp1->counters.incoming/1000, cp1->counters.outgoing/1000);
 				if (cp1->fw_connection_state == FW_MARK_AUTHENTICATED) {
 					iptables_fw_access(AUTH_MAKE_DEAUTHENTICATED, cp1);
 				}
@@ -178,8 +178,8 @@ fw_refresh_client_list(void)
 			} else if (added_time +  (config->checkinterval * config->clientforceout) <= now) {
 				/* Forcing out user */
 				debug(LOG_NOTICE, "%s %s connected %d secs. kB in: %llu kB out: %llu",
-					cp1->ip, cp1->mac, config->checkinterval * config->clientforceout,
-					cp1->counters.incoming/1000, cp1->counters.outgoing/1000);
+					  cp1->ip, cp1->mac, config->checkinterval * config->clientforceout,
+					  cp1->counters.incoming/1000, cp1->counters.outgoing/1000);
 				if (cp1->fw_connection_state == FW_MARK_AUTHENTICATED) {
 					iptables_fw_access(AUTH_MAKE_DEAUTHENTICATED, cp1);
 				}

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -194,10 +194,15 @@ fw_refresh_client_list(void)
 const char *
 fw_connection_state_as_string(int mark)
 {
-	if(mark == FW_MARK_PREAUTHENTICATED) return "Preauthenticated";
-	if(mark == FW_MARK_AUTHENTICATED) return "Authenticated";
-	if(mark == FW_MARK_TRUSTED) return "Trusted";
-	if(mark == FW_MARK_BLOCKED) return "Blocked";
+	if (mark == FW_MARK_PREAUTHENTICATED)
+		return "Preauthenticated";
+	if (mark == FW_MARK_AUTHENTICATED)
+		return "Authenticated";
+	if (mark == FW_MARK_TRUSTED)
+		return "Trusted";
+	if (mark == FW_MARK_BLOCKED)
+		return "Blocked";
+
 	return "ERROR: unrecognized mark";
 }
 

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -37,7 +37,7 @@
 #include <pthread.h>
 #include <sys/wait.h>
 #include <sys/types.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 #include <string.h>
 

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -479,9 +479,9 @@ iptables_fw_init(void)
 	/* CHAIN_TO_ROUTER packets marked BLOCKED  DROP */
 	rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -m mark --mark 0x%x%s -j DROP", FW_MARK_BLOCKED, markmask);
 	/* CHAIN_TO_ROUTER, invalid packets  DROP */
-	rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -m state --state INVALID -j DROP");
+	rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -m conntrack --ctstate INVALID -j DROP");
 	/* CHAIN_TO_ROUTER, related and established packets  ACCEPT */
-	rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -m state --state RELATED,ESTABLISHED -j ACCEPT");
+	rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT");
 	/* CHAIN_TO_ROUTER, bogus SYN packets  DROP */
 	rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -p tcp --tcp-flags SYN SYN \\! --tcp-option 2 -j  DROP");
 
@@ -500,7 +500,7 @@ iptables_fw_init(void)
 	} else {
 		rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -m mark --mark 0x%x%s -j " CHAIN_TRUSTED_TO_ROUTER, FW_MARK_TRUSTED, markmask);
 		/* CHAIN_TRUSTED_TO_ROUTER, related and established packets  ACCEPT */
-		rc |= iptables_do_command("-t filter -A " CHAIN_TRUSTED_TO_ROUTER " -m state --state RELATED,ESTABLISHED -j ACCEPT");
+		rc |= iptables_do_command("-t filter -A " CHAIN_TRUSTED_TO_ROUTER " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT");
 		/* CHAIN_TRUSTED_TO_ROUTER, append the "trusted-users-to-router" ruleset */
 		rc |= _iptables_append_ruleset("filter", "trusted-users-to-router", CHAIN_TRUSTED_TO_ROUTER);
 		/* CHAIN_TRUSTED_TO_ROUTER, any packets not matching that ruleset  REJECT */
@@ -533,7 +533,7 @@ iptables_fw_init(void)
 	/* CHAIN_TO_INTERNET packets marked BLOCKED  DROP */
 	rc |= iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%x%s -j DROP", FW_MARK_BLOCKED, markmask);
 	/* CHAIN_TO_INTERNET, invalid packets  DROP */
-	rc |= iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m state --state INVALID -j DROP");
+	rc |= iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m conntrack --ctstate INVALID -j DROP");
 	/* CHAIN_TO_INTERNET, deal with MSS */
 	if (set_mss) {
 		/* XXX this mangles, so 'should' be done in the mangle POSTROUTING chain.
@@ -558,7 +558,7 @@ iptables_fw_init(void)
 	} else {
 		rc |= iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%x%s -j " CHAIN_TRUSTED, FW_MARK_TRUSTED, markmask);
 		/* CHAIN_TRUSTED, related and established packets  ACCEPT */
-		rc |= iptables_do_command("-t filter -A " CHAIN_TRUSTED " -m state --state RELATED,ESTABLISHED -j ACCEPT");
+		rc |= iptables_do_command("-t filter -A " CHAIN_TRUSTED " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT");
 		/* CHAIN_TRUSTED, append the "trusted-users" ruleset */
 		rc |= _iptables_append_ruleset("filter", "trusted-users", CHAIN_TRUSTED);
 		/* CHAIN_TRUSTED, any packets not matching that ruleset  REJECT */
@@ -578,7 +578,7 @@ iptables_fw_init(void)
 	} else {
 		rc |= iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%x%s -j " CHAIN_AUTHENTICATED, FW_MARK_AUTHENTICATED, markmask);
 		/* CHAIN_AUTHENTICATED, related and established packets  ACCEPT */
-		rc |= iptables_do_command("-t filter -A " CHAIN_AUTHENTICATED " -m state --state RELATED,ESTABLISHED -j ACCEPT");
+		rc |= iptables_do_command("-t filter -A " CHAIN_AUTHENTICATED " -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT");
 		/* CHAIN_AUTHENTICATED, append the "authenticated-users" ruleset */
 		rc |= _iptables_append_ruleset("filter", "authenticated-users", CHAIN_AUTHENTICATED);
 		/* CHAIN_AUTHENTICATED, any packets not matching that ruleset  REJECT */

--- a/src/util.c
+++ b/src/util.c
@@ -38,7 +38,7 @@
 #include <pthread.h>
 #include <sys/wait.h>
 #include <sys/types.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>
 #include <arpa/inet.h>

--- a/src/util.c
+++ b/src/util.c
@@ -542,7 +542,12 @@ get_status_text()
 		len = strlen(buffer);
 		free(str);
 
-		durationsecs = now - client->added_time;
+		if(now > client->added_time) {
+			durationsecs = now - client->added_time;
+		} else {
+			// prevent divison by 0 later
+			durationsecs = 1;
+		}
 
 		str = format_time(durationsecs);
 		snprintf((buffer + len), (sizeof(buffer) - len), "  Added duration:  %s\n", str);

--- a/src/util.c
+++ b/src/util.c
@@ -162,7 +162,8 @@ execute(const char cmd_line[], int quiet)
 }
 
 struct in_addr *
-wd_gethostbyname(const char name[]) {
+wd_gethostbyname(const char name[])
+{
 	struct hostent *he;
 	struct in_addr *h_addr, *in_addr_temp;
 
@@ -738,7 +739,7 @@ get_clients_json(void)
 
 	snprintf((buffer + len), (sizeof(buffer) - len), "\"clients\":{\n");
 	len = strlen(buffer);
-	
+
 	while (client != NULL) {
 		snprintf((buffer + len), (sizeof(buffer) - len), "\"%s\":{\n", client->mac);
 		len = strlen(buffer);


### PR DESCRIPTION
@01010000101001100
does compile in v 1.0.0

--- a/src/firewall.c    2016-08-03 10:33:21.513311228 +0200
+++ b/src/firewall.c    2016-08-03 10:47:28.424565842 +0200
@@ -173,7 +173,7 @@
                debug(LOG_NOTICE, "%s %s inactive %d secs. kB in: %llu  kB out: %llu",
                      cp1->ip, cp1->mac, config->checkinterval \* config->clienttimeout,
                      cp1->counters.incoming/1000, cp1->counters.outgoing/1000);
-               if(cp1->fw_connection_state == FW_MARK_AUTHENTICATED) {
-               if(cp1->fw_connection_state == FW_MARK_AUTHENTICATED || cp1->fw_connection_state == FW_MARK_PREAUTHENTICATED) {
                  iptables_fw_access(AUTH_MAKE_DEAUTHENTICATED, cp1);
              }
              client_list_delete(cp1);
  @@ -182,7 +182,7 @@
              debug(LOG_NOTICE, "%s %s connected %d secs. kB in: %llu kB out: %llu",
                    cp1->ip, cp1->mac, config->checkinterval \* config->clientforceout,
                    cp1->counters.incoming/1000, cp1->counters.outgoing/1000);
-               if(cp1->fw_connection_state == FW_MARK_AUTHENTICATED) {
-               if(cp1->fw_connection_state == FW_MARK_AUTHENTICATED || cp1->fw_connection_state == FW_MARK_PREAUTHENTICATED) {
                  iptables_fw_access(AUTH_MAKE_DEAUTHENTICATED, cp1);
              }
              client_list_delete(cp1);
