### PR TITLE
Debian systemd support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Shiao-An Yuan <shiao.an.yuan@gmail.com>
 Uploaders: Moritz Warning <moritzwarning@web.de>, Steffen Moeller <moeller@debian.org>
-Build-Depends: debhelper (>= 8.0.0), dpkg-dev (>= 1.16.1~)
+Build-Depends: debhelper (>= 8.0.0), dpkg-dev (>= 1.16.1~), dh-systemd (>= 1.5)
 Standards-Version: 3.9.6
 Homepage: http://kokoro.ucsd.edu/nodogsplash/
 Vcs-Git: git://github.com/nodogsplash/nodogsplash.git

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: http://github.com/nodogsplash/nodogsplash
 
 Package: nodogsplash
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, libmicrohttpd12 (>= 0.9.50)
 Description: manage access to public internet access
  Nodogsplash controls access to a public Internet connection and offers
  a simple way to open a Hotspot for wireless networks. It provides a

--- a/debian/nodogsplash.service
+++ b/debian/nodogsplash.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NoDogSplash Captive Portal
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/nodogsplash -d 5 $OPTIONS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -15,4 +15,4 @@ export CFLAGS += -flto
 export LDFLAGS += -flto
 
 %:
-	dh $@ 
+	dh $@ --with systemd


### PR DESCRIPTION
Adds support to systemd systems (ie: debian jessie) and adds libmicrohttpd (>= 0.9.50) to package deps.

BTW: libmicrohttpd needs to be installed by tarbar or sid repository. The current version on stable repositories is lower then required version.