### PR TITLE
Fix segfault when mimetype isn't found (#216)

### DIFF
--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -946,6 +946,8 @@ const char *lookup_mimetype(const char *filename)
 		}
 	}
 
+	debug(LOG_INFO, "Could not find corresponding mimetype for %s extension", extension);
+
 	return DEFAULT_MIME_TYPE;
 }
 

--- a/src/mimetypes.h
+++ b/src/mimetypes.h
@@ -88,7 +88,12 @@ static const struct mimetype uh_mime_types[] = {
 	{ "pac",		"application/x-ns-proxy-autoconfig" },
 	{ "wpad.dat",	"application/x-ns-proxy-autoconfig" },
 
-	{ NULL, NULL }
+	{ "woff",		"application/x-font-woff" },
+	{ "woff2",		"application/x-font-woff2" },
+	{ "ttf",		"application/x-font-ttf" },
+	{ "eot",		"application/vnd.ms-fontobject" },
+	{ "svg",		"image/svg+xml" },
+	{ "otf",		"application/x-font-opentype" },
 };
 
 #endif


### PR DESCRIPTION
The segfault was due to the mimetype not being found by the lookup_mimetype method.

In the mimetypes.h the last entry was "NULL,NULL", causing a strcmp with a NULL value, which lead to a segfault.

I've removed the "NULL, NULL" entry in the mimetypes.h as it would segfault every time a mimetype wasn't found.

I also added font related mimetypes, wasn't mandatory but it's better to have them.