### PR TITLE
Allow Chaining to Existing Firewall Rules

### DIFF
--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -436,9 +436,9 @@ iptables_fw_init(void)
 	// packets coming in on gw_interface jump to CHAIN_OUTGOING
 	rc |= iptables_do_command("-t nat -I PREROUTING -i %s -s %s -j " CHAIN_OUTGOING, gw_interface, gw_iprange);
 	// CHAIN_OUTGOING, packets marked TRUSTED  ACCEPT
-	rc |= iptables_do_command("-t nat -A " CHAIN_OUTGOING " -m mark --mark 0x%x%s -j ACCEPT", FW_MARK_TRUSTED, markmask);
+	rc |= iptables_do_command("-t nat -A " CHAIN_OUTGOING " -m mark --mark 0x%x%s -j RETURN", FW_MARK_TRUSTED, markmask);
 	// CHAIN_OUTGOING, packets marked AUTHENTICATED  ACCEPT
-	rc |= iptables_do_command("-t nat -A " CHAIN_OUTGOING " -m mark --mark 0x%x%s -j ACCEPT",FW_MARK_AUTHENTICATED, markmask);
+	rc |= iptables_do_command("-t nat -A " CHAIN_OUTGOING " -m mark --mark 0x%x%s -j RETURN", FW_MARK_AUTHENTICATED, markmask);
 	// CHAIN_OUTGOING, append the "preauthenticated-users" ruleset
 	rc |= _iptables_append_ruleset("nat", "preauthenticated-users", CHAIN_OUTGOING);
 


### PR DESCRIPTION
Allow chaining to existing iptables rules for Trusted and Authenticated clients by changing from ACCEPT to RETURN in the NDS iptables settings. 
Tested on LEDE 170104. Also works for NDS version 1. See #229
Author-name: Rob White
Signed-off-by: Rob White <rob@blue-wave.net>