### PR TITLE
microhttpd: Use TCP Fastopen option

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -255,7 +255,7 @@ main_loop(void)
 
 	/* Initializes the web server */
 	if ((webserver = MHD_start_daemon(
-						MHD_USE_EPOLL_INTERNALLY,
+						MHD_USE_EPOLL_INTERNALLY | MHD_USE_TCP_FASTOPEN,
 						config->gw_port,
 						NULL, NULL,
 						libmicrohttpd_cb, NULL,


### PR DESCRIPTION
#### TCP Fast Open
An extension to speed up the opening of successive Transmission Control Protocol (TCP) connections between two endpoint.

#### libmicrohttpd support status
libmicrohttpd support [TCP Fast Open](https://en.wikipedia.org/wiki/TCP_Fast_Open) (Since 0.9.34)

nodogsplash use libmicrohttpd 0.9.51, so we can use this option to improve speed when get splash pages.

Thanks! :)
