### PR TITLE
Forward Authentication Service (FAS) Integration.

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,4 +1,4 @@
-Frequenctly Asked Questions
+Frequently Asked Questions
 ###########################
 
 What's the difference between v0.9, v1, v2 and v3?
@@ -26,7 +26,7 @@ Can I update from v0.9/v1 to v2.0.0
 
 You can, if you don't use:
 
-* BinVoucher (there is a `PR#144 <https://github.com/nodogsplash/nodogsplash/pull/144>`_)
+* BinVoucher
 
 I would like to use QoS or TrafficControl on OpenWrt
 ****************************************************

--- a/docs/source/howitworks.rst
+++ b/docs/source/howitworks.rst
@@ -1,11 +1,49 @@
-How nodogsplash works
-#####################
+How nodogsplash (NDS) works
+###########################
 
-A wireless router running OpenWrt has two or more interfaces; nodogsplash
+A wireless router running OpenWrt has two or more interfaces; NDS
 manages one of them. This will typically be br-lan, the bridge to both the
-wireless and wired LAN; or the wireless lan interface may be named something
-else if you have broken the br-lan bridge to separate the wired and wireless
-LAN's.
+wireless and wired LAN; or could be for example wlan0 if you wanted NDS
+to work just on the wireless interface.
+
+A simplified summary of operation is as follows:
+************************************************
+
+By default, NDS blocks everything, but intercepts port 80 requests.
+
+An initial port 80 request will be generated on a client device, either by the user
+manually browsing to an http web page, or automatically by the client device's
+built in Captive Portal Detection (CPD).
+
+As soon as this initial port 80 request is received, NDS will redirect the client to either
+its own splash page, or a splash page on a configured Forwarding Authentication Service (FAS).
+
+The user of the client device will then be expected to complete some actions
+on the splash page, such as accepting terms of service, entering a username and password
+etc. (this will of course be on either the basic NDS splash.html or the page presented
+by the FAS, depending on the NDS configuration).
+
+Once the user on the client device has sucessfully completed the splash page
+actions, the page then links directly, with a query string, to an NDS virtual http directory
+provided by NDS's built in web server.
+
+For security, NDS expects to receive the same valid token it allocated when
+the client issued its initial port 80 request. If the token received is valid,
+NDS then "authenticates" the client device, allowing access to the Internet.
+
+However if Binauth is enabled, NDS first calls the Binauth script, passing if required a username and password to that script.
+If the binauth script returns positively (ie return code 0), NDS then "authenticates" the
+client device, allowing access to the Internet.
+
+In FAS secure mode, it is the responsibility of the FAS to obtain the client token in a secure manner from NDS.
+
+When FAS is disabled, the token is supplied to the basic splash.html page served by NDS
+and passed back in clear text in the query string along with any username and password required for Binauth.
+
+.. note::
+FAS and Binauth can be enabled together.
+This can give great flexibility with FAS providing authentication
+and Binauth providing post authentication processing closely linked to NDS.
 
 Packet filtering
 ****************
@@ -52,15 +90,8 @@ configurations.
 Traffic control
 ***************
 
-Nodogsplash also optionally implements basic traffic control on its managed
-interface. This feature lets you specify the maximum aggregate upload and
-download bandwidth that can be taken by clients connected on that interface.
-Nodogsplash implements this functionality by enabling two intermediate queue
-devices (IMQ's), one for upload and one for download, and attaching simple
-rate-limited HTB qdiscs to them. Rules are inserted in the router's iptables
-mangle PREROUTING and POSTROUTING tables to jump to these IMQ's. The result is
-simple but effective tail-drop rate limiting (no packet classification or
-fairness queueing is done).
+Data rate control on an IP connection basis can be achived using SQM scripts
+configured separately, with NDS being fully compatible.
 
-.. note::
-   IMQ is not included anymore by OpenWrt Attitude Adjustment (12.09).
+It should be noted that while setup options and binauth do accept traffic/quota settings,
+these values currently have no effect and are reserved for future development.

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -401,17 +401,16 @@ FirewallRuleSet users-to-router {
 #
 # BinAuth /bin/myauth.sh
 
-# Nodogsplash uses specific values to mark packets using iptables.
-# Parameter: FW_MARK_BLOCKED
-# Default: 0x100
+# Nodogsplash uses specific HEXADECIMAL values to mark packets used by iptables as a bitwise mask.
+# This mask can conflict with the requirements of other packages such as mwan3, sqm etc
+# Any values set here are interpreted as in hex format.
 #
-# Parameter: FW_MARK_TRUSTED
-# Default: 0x200
+# Parameter: fw_mark_authenticated
+# Default: 30000 (0011|0000|0000|0000|0000 binary)
 #
-# Parameter: FW_MARK_AUTHENTICATED
-# Default: 0x400
+# Parameter: fw_mark_trusted
+# Default: 20000 (0010|0000|0000|0000|0000 binary)
 #
-# Set FW_MARK for compatibilty with other Packages eg mwan3, sqm etc.
-fw_mark_authenticated 30000
-fw_mark_trusted 20000
-fw_mark_blocked 10000
+# Parameter: fw_mark_blocked
+# Default: 10000 (0001|0000|0000|0000|0000 binary)
+#

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -337,6 +337,39 @@ FirewallRuleSet users-to-router {
 #
 #  DebugLevel 5
 
+# Parameter: fasport
+# Default: None
+#
+# Enable Forwarding Authentication Service (FAS)
+# If set redirection is changed from splash.html to a FAS (provided by the system administrator)
+# The value is the IP port number of the FAS
+#
+# fasport 2080
+
+# Parameter: fasremoteip
+# Default: GatewayAddress (the IP of NDS)
+#
+# If set, this is the remote ip address of the FAS.
+#
+# fasremoteip 46.32.240.41
+
+# Parameter: faspath
+# Default: /
+#
+# This is the path to the login page on the FAS.
+#
+# faspath /nodog/fas.php
+
+# Parameter: fas_secure_enabled
+# Default: 1
+#
+# If set to "1", authaction and the client token are not revealed and it is the responsibility
+# of the FAS to request the token from NDSCTL.
+# If set to "0", the client token is sent to the FAS in clear text in the query string of the
+# redirect along with authaction and redir.
+#
+# fas_secure_enabled 0
+
 # Parameter: BinAuth
 #
 # Enable BinAuth Support.

--- a/src/conf.c
+++ b/src/conf.c
@@ -152,9 +152,9 @@ static const struct {
 	{ "blockedmaclist", oBlockedMACList },
 	{ "allowedmaclist", oAllowedMACList },
 	{ "MACmechanism", oMACmechanism },
-	{ "FW_MARK_AUTHENTICATED", oFWMarkAuthenticated },
-	{ "FW_MARK_TRUSTED", oFWMarkTrusted },
-	{ "FW_MARK_BLOCKED", oFWMarkBlocked },
+	{ "fw_mark_authenticated", oFWMarkAuthenticated },
+	{ "fw_mark_trusted", oFWMarkTrusted },
+	{ "fw_mark_blocked", oFWMarkBlocked },
 	{ "binauth", oBinAuth },
 	{ NULL, oBadOption },
 };
@@ -228,9 +228,9 @@ config_init(void)
 	config.blockedmaclist = NULL;
 	config.allowedmaclist = NULL;
 	config.macmechanism = DEFAULT_MACMECHANISM;
-	config.FW_MARK_AUTHENTICATED = DEFAULT_FW_MARK_AUTHENTICATED;
-	config.FW_MARK_TRUSTED = DEFAULT_FW_MARK_TRUSTED;
-	config.FW_MARK_BLOCKED = DEFAULT_FW_MARK_BLOCKED;
+	config.fw_mark_authenticated = DEFAULT_FW_MARK_AUTHENTICATED;
+	config.fw_mark_trusted = DEFAULT_FW_MARK_TRUSTED;
+	config.fw_mark_blocked = DEFAULT_FW_MARK_BLOCKED;
 	config.ip6 = DEFAULT_IP6;
 	config.binauth = NULL;
 
@@ -891,30 +891,30 @@ config_read(const char *filename)
 			}
 			break;
 		case oFWMarkAuthenticated:
-			if (sscanf(p1, "%x", &config.FW_MARK_AUTHENTICATED) < 1 ||
-					config.FW_MARK_AUTHENTICATED == 0 ||
-					config.FW_MARK_AUTHENTICATED == config.FW_MARK_BLOCKED ||
-					config.FW_MARK_AUTHENTICATED == config.FW_MARK_TRUSTED) {
+			if (sscanf(p1, "%x", &config.fw_mark_authenticated) < 1 ||
+					config.fw_mark_authenticated == 0 ||
+					config.fw_mark_authenticated == config.fw_mark_blocked ||
+					config.fw_mark_authenticated == config.fw_mark_trusted) {
 				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
 				debug(LOG_ERR, "Exiting...");
 				exit(-1);
 			}
 			break;
 		case oFWMarkBlocked:
-			if (sscanf(p1, "%x", &config.FW_MARK_BLOCKED) < 1 ||
-					config.FW_MARK_BLOCKED == 0 ||
-					config.FW_MARK_BLOCKED == config.FW_MARK_AUTHENTICATED ||
-					config.FW_MARK_BLOCKED == config.FW_MARK_TRUSTED) {
+			if (sscanf(p1, "%x", &config.fw_mark_blocked) < 1 ||
+					config.fw_mark_blocked == 0 ||
+					config.fw_mark_blocked == config.fw_mark_authenticated ||
+					config.fw_mark_blocked == config.fw_mark_trusted) {
 				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
 				debug(LOG_ERR, "Exiting...");
 				exit(-1);
 			}
 			break;
 		case oFWMarkTrusted:
-			if (sscanf(p1, "%x", &config.FW_MARK_TRUSTED) < 1 ||
-					config.FW_MARK_TRUSTED == 0 ||
-					config.FW_MARK_TRUSTED == config.FW_MARK_AUTHENTICATED ||
-					config.FW_MARK_TRUSTED == config.FW_MARK_BLOCKED) {
+			if (sscanf(p1, "%x", &config.fw_mark_trusted) < 1 ||
+					config.fw_mark_trusted == 0 ||
+					config.fw_mark_trusted == config.fw_mark_authenticated ||
+					config.fw_mark_trusted == config.fw_mark_blocked) {
 				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
 				debug(LOG_ERR, "Exiting...");
 				exit(-1);

--- a/src/conf.c
+++ b/src/conf.c
@@ -73,6 +73,10 @@ typedef enum {
 	oGatewayIPRange,
 	oGatewayAddress,
 	oGatewayPort,
+	oFasPort,
+	oFasPath,
+	oFasRemoteIP,
+	oFasSecureEnabled,
 	oHTTPDMaxConn,
 	oWebRoot,
 	oSplashPage,
@@ -120,6 +124,10 @@ static const struct {
 	{ "gatewayiprange", oGatewayIPRange },
 	{ "gatewayaddress", oGatewayAddress },
 	{ "gatewayport", oGatewayPort },
+	{ "fasport", oFasPort },
+	{ "fasremoteip", oFasRemoteIP },
+	{ "fas_secure_enabled", oFasSecureEnabled },
+	{ "faspath", oFasPath },
 	{ "webroot", oWebRoot },
 	{ "splashpage", oSplashPage },
 	{ "statuspage", oStatusPage },
@@ -189,6 +197,10 @@ config_init(void)
 	config.gw_iprange = safe_strdup(DEFAULT_GATEWAY_IPRANGE);
 	config.gw_address = NULL;
 	config.gw_port = DEFAULT_GATEWAYPORT;
+	config.fas_port = DEFAULT_FASPORT;
+	config.fas_secure_enabled = DEFAULT_FAS_SECURE_ENABLED;
+	config.fas_remoteip = NULL;
+	config.fas_path = DEFAULT_FASPATH;
 	config.webroot = safe_strdup(DEFAULT_WEBROOT);
 	config.splashpage = safe_strdup(DEFAULT_SPLASHPAGE);
 	config.statuspage = safe_strdup(DEFAULT_STATUSPAGE);
@@ -741,6 +753,26 @@ config_read(const char *filename)
 				debug(LOG_ERR, "Exiting...");
 				exit(-1);
 			}
+			break;
+		case oFasPort:
+			if (sscanf(p1, "%u", &config.fas_port) < 1) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(-1);
+			}
+			break;
+		case oFasSecureEnabled:
+			if (sscanf(p1, "%d", &config.fas_secure_enabled) < 1) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(-1);
+			}
+			break;
+		case oFasPath:
+			config.fas_path = safe_strdup(p1);
+			break;
+		case oFasRemoteIP:
+			config.fas_remoteip = safe_strdup(p1);
 			break;
 		case oBinAuth:
 			config.binauth = safe_strdup(p1);

--- a/src/conf.h
+++ b/src/conf.h
@@ -78,9 +78,9 @@
 #define DEFAULT_SYSLOG_FACILITY LOG_DAEMON
 #define DEFAULT_NDSCTL_SOCK "/tmp/ndsctl.sock"
 #define DEFAULT_INTERNAL_SOCK "/tmp/ndsctl.sock"
-#define DEFAULT_FW_MARK_AUTHENTICATED 0x400
-#define DEFAULT_FW_MARK_TRUSTED 0x200
-#define DEFAULT_FW_MARK_BLOCKED 0x100
+#define DEFAULT_FW_MARK_AUTHENTICATED 0x30000
+#define DEFAULT_FW_MARK_TRUSTED 0x20000
+#define DEFAULT_FW_MARK_BLOCKED 0x10000
 /* N.B.: default policies here must be ACCEPT, REJECT, or RETURN
  * In the .conf file, they must be allow, block, or passthrough
  * Mapping between these enforced by parse_empty_ruleset_policy() */
@@ -179,9 +179,9 @@ typedef struct {
 	t_MAC *trustedmaclist;		/**< @brief list of trusted macs */
 	t_MAC *blockedmaclist;		/**< @brief list of blocked macs */
 	t_MAC *allowedmaclist;		/**< @brief list of allowed macs */
-	unsigned int FW_MARK_AUTHENTICATED;	/**< @brief iptables mark for authenticated packets */
-	unsigned int FW_MARK_BLOCKED;	/**< @brief iptables mark for blocked packets */
-	unsigned int FW_MARK_TRUSTED;	/**< @brief iptables mark for trusted packets */
+	unsigned int fw_mark_authenticated;	/**< @brief iptables mark for authenticated packets */
+	unsigned int fw_mark_blocked;	/**< @brief iptables mark for blocked packets */
+	unsigned int fw_mark_trusted;	/**< @brief iptables mark for trusted packets */
 	int ip6;			/**< @brief enable IPv6 */
 	char *binauth;		/**< @brief external authentication program */
 } s_config;

--- a/src/conf.h
+++ b/src/conf.h
@@ -52,6 +52,9 @@
 #define DEFAULT_GATEWAY_IPRANGE "0.0.0.0/0"
 #define DEFAULT_GATEWAYNAME "NoDogSplash"
 #define DEFAULT_GATEWAYPORT 2050
+#define DEFAULT_FASPORT 0
+#define DEFAULT_FAS_SECURE_ENABLED 1
+#define DEFAULT_FASPATH "/"
 #define DEFAULT_REMOTE_AUTH_PORT 80
 #define DEFAULT_CHECKINTERVAL 30
 #define DEFAULT_SESSION_TIMEOUT 0
@@ -147,6 +150,10 @@ typedef struct {
 	char *gw_address;		/**< @brief Internal IP address for our web server */
 	char *gw_mac;			/**< @brief MAC address of the interface we manage */
 	unsigned int gw_port;		/**< @brief Port the webserver will run on */
+	unsigned int fas_port;		/**< @brief Port the fas server will run on */
+	int fas_secure_enabled;		/**< @brief Enable Secure FAS */
+	char *fas_path;			/**< @brief Path to forward authentication page of FAS */
+	char *fas_remoteip;		/**< @brief IP addess of a remote FAS */
 	char *webroot;			/**< @brief Directory containing splash pages, etc. */
 	char *splashpage;		/**< @brief Name of main splash page */
 	char *statuspage;		/**< @brief Name of info status page */

--- a/src/conf.h
+++ b/src/conf.h
@@ -164,14 +164,14 @@ typedef struct {
 	char *denydir;			/**< @brief Notional relative dir for denial URL */
 	int session_timeout;		/**< @brief Minutes of the default session length */
 	int preauth_idle_timeout;	/**< @brief Minutes a preauthenticated client will be kept in the system */
-	int auth_idle_timeout;	/**< @brief Minutes a authenticated client will be kept in the system */
+	int auth_idle_timeout;		/**< @brief Minutes an authenticated client will be kept in the system */
 	int checkinterval;		/**< @brief Period the the client timeout check thread will run, in seconds */
 	int set_mss;			/**< @brief boolean, whether to set mss */
 	int mss_value;			/**< @brief int, mss value; <= 0 clamp to pmtu */
 	int traffic_control;		/**< @brief boolean, whether to do tc */
 	int download_limit;		/**< @brief Download limit, kb/s */
 	int upload_limit;		/**< @brief Upload limit, kb/s */
-	int upload_ifb;		/**< @brief Number of IFB handling upload */
+	int upload_ifb;			/**< @brief Number of IFB handling upload */
 	int log_syslog;			/**< @brief boolean, whether to log to syslog */
 	int syslog_facility;		/**< @brief facility to use when using syslog for logging */
 	int macmechanism; 		/**< @brief mechanism wrt MAC addrs */
@@ -183,7 +183,7 @@ typedef struct {
 	unsigned int fw_mark_blocked;	/**< @brief iptables mark for blocked packets */
 	unsigned int fw_mark_trusted;	/**< @brief iptables mark for trusted packets */
 	int ip6;			/**< @brief enable IPv6 */
-	char *binauth;		/**< @brief external authentication program */
+	char *binauth;			/**< @brief external authentication program */
 } s_config;
 
 /** @brief Get the current gateway configuration */

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -347,6 +347,8 @@ iptables_fw_init(void)
 	char *gw_address = NULL;
 	char *gw_iprange = NULL;
 	int gw_port = 0;
+	char *fas_remoteip;
+	int fas_port;
 	int traffic_control;
 	int set_mss, mss_value;
 	t_MAC *pt;
@@ -361,6 +363,8 @@ iptables_fw_init(void)
 	gw_address = safe_strdup(config->gw_address);    /* must free */
 	gw_iprange = safe_strdup(config->gw_iprange);    /* must free */
 	gw_port = config->gw_port;
+	fas_remoteip = config->fas_remoteip;
+	fas_port = config->fas_port;
 	pt = config->trustedmaclist;
 	pb = config->blockedmaclist;
 	pa = config->allowedmaclist;
@@ -458,6 +462,11 @@ iptables_fw_init(void)
 	// CHAIN_OUTGOING, append the "preauthenticated-users" ruleset
 	rc |= _iptables_append_ruleset("nat", "preauthenticated-users", CHAIN_OUTGOING);
 
+	// Allow access to remote FAS - CHAIN_OUTGOING and CHAIN_TO_INTERNET packets for remote FAS, ACCEPT
+	if (fas_port && fas_remoteip) {
+		rc |= iptables_do_command("-t nat -A " CHAIN_OUTGOING " -p tcp --destination %s --dport %d -j ACCEPT", fas_remoteip, fas_port);
+	}
+
 	// CHAIN_OUTGOING, packets for tcp port 80, redirect to gw_port on primary address for the iface
 	rc |= iptables_do_command("-t nat -A " CHAIN_OUTGOING " -p tcp --dport 80 -j DNAT --to-destination %s:%d", gw_address, gw_port);
 	// CHAIN_OUTGOING, other packets ACCEPT
@@ -499,6 +508,11 @@ iptables_fw_init(void)
 
 	// CHAIN_TO_ROUTER, packets to HTTP listening on gw_port on router ACCEPT
 	rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -p tcp --dport %d -j ACCEPT", gw_port);
+
+	// CHAIN_TO_ROUTER, packets to HTTP listening on fas_port on router ACCEPT
+	if (fas_port && !fas_remoteip) {
+		rc |= iptables_do_command("-t filter -A " CHAIN_TO_ROUTER " -p tcp --dport %d -j ACCEPT", fas_port);
+	}
 
 	// CHAIN_TO_ROUTER, packets marked TRUSTED:
 
@@ -556,6 +570,12 @@ iptables_fw_init(void)
 		} else { /* allow MSS as large as possible */
 			rc |= iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu");
 		}
+	}
+
+
+	// Allow access to remote FAS - CHAIN_OUTGOING and CHAIN_TO_INTERNET packets for remote FAS, ACCEPT
+	if (fas_remoteip && fas_port) {
+		rc |= iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -p tcp --destination %s --dport %d -j ACCEPT", fas_remoteip, fas_port);
 	}
 
 	/* CHAIN_TO_INTERNET, packets marked TRUSTED: */

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -372,9 +372,9 @@ iptables_fw_init(void)
 	set_mss = config->set_mss;
 	mss_value = config->mss_value;
 	traffic_control = config->traffic_control;
-	FW_MARK_BLOCKED = config->FW_MARK_BLOCKED;
-	FW_MARK_TRUSTED = config->FW_MARK_TRUSTED;
-	FW_MARK_AUTHENTICATED = config->FW_MARK_AUTHENTICATED;
+	FW_MARK_BLOCKED = config->fw_mark_blocked;
+	FW_MARK_TRUSTED = config->fw_mark_trusted;
+	FW_MARK_AUTHENTICATED = config->fw_mark_authenticated;
 	UNLOCK_CONFIG();
 
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -267,6 +267,19 @@ main_loop(void)
 		httpdAddC404Content(webserver, http_nodogsplash_callback_404);
 	*/
 
+	if (config->fas_port) {
+		debug(LOG_NOTICE, "Forwarding Authentication is Enabled.\n");
+		if (config->fas_remoteip) {
+			debug(LOG_NOTICE, "FAS URL is http://%s:%u%s\n", config->fas_remoteip, config->fas_port, config->fas_path);
+		} else {
+			debug(LOG_NOTICE, "FAS URL is http://%s:%u%s\n", config->gw_address, config->fas_port, config->fas_path);
+		}
+	}
+
+	if (config->fas_secure_enabled != 1 && config->fas_port) {
+		debug(LOG_NOTICE, "Warning - Forwarding Authentication - Security is DISABLED.\n");
+	}
+
 	/* Reset the firewall (cleans it, in case we are restarting after nodogsplash crash) */
 	iptables_fw_destroy();
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -280,6 +280,11 @@ main_loop(void)
 		debug(LOG_NOTICE, "Warning - Forwarding Authentication - Security is DISABLED.\n");
 	}
 
+	if (config->binauth) {
+		debug(LOG_NOTICE, "Binauth is Enabled.\n");
+		debug(LOG_NOTICE, "Binauth Script is %s\n", config->binauth);
+	}
+
 	/* Reset the firewall (cleans it, in case we are restarting after nodogsplash crash) */
 	iptables_fw_destroy();
 


### PR DESCRIPTION
This implements redirection to an external authentication
service in place of splash.html.

It introduces four new options:

1. fasport - if set, enables FAS redirection and the value is
the port used for access.

2. fasremoteip - if set is the ip address of the FAS, defaults
to the NDS gateway address for the case of FAS running locally to NDS.

3. faspath - the path on FAS to the login page. Default "/"

4. fas_secure_enabled - if set to "1", the client token is not
revealed and it is the responsibility of the FAS to request
this from NDS. If set to "0", the client token is passed in
clear text in the query string to the FAS.

Firewall settings are automatically configured for access to the FAS.

Binauth can also be configured at the same time to allow a local
script to be called on authentication.

Signed-off-by: Rob White <rob@blue-wave.net>