### PR TITLE
Add FAS and Binauth to ndsctl status

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -438,6 +438,22 @@ ndsctl_status(FILE *fp)
 	fprintf(fp, "Managed interface: %s\n", config->gw_interface);
 	fprintf(fp, "Managed IP range: %s\n", config->gw_iprange);
 	fprintf(fp, "Server listening: %s:%d\n", config->gw_address, config->gw_port);
+
+	if (config->binauth) {
+		fprintf(fp, "Binauth Script: %s\n", config->binauth);
+	} else {
+		fprintf(fp, "Binauth: Disabled\n");
+	}
+
+	if (config->fas_port) {
+		fprintf(fp, "FAS: Secure=%u URL: http://%s:%u%s\n",
+			config->fas_secure_enabled,
+			config->fas_remoteip ? config->fas_remoteip : config->gw_address,
+			config->fas_port, config->fas_path);
+	} else {
+		fprintf(fp, "FAS: Disabled\n");
+	}
+
 	fprintf(fp, "Client Check Interval: %ds\n", config->checkinterval);
 	fprintf(fp, "Preauth Idle Timeout: %dm\n", config->preauth_idle_timeout);
 	fprintf(fp, "Auth Idle Timeout: %dm\n", config->auth_idle_timeout);


### PR DESCRIPTION
Show the configuration of both Binauth and FAS in the output of ndsctl status.

Signed-off-by: Rob White <rob@blue-wave.net>