### PR TITLE
Custom tag names - html 5.2 compliance

### DIFF
--- a/resources/splash.css
+++ b/resources/splash.css
@@ -26,27 +26,27 @@ input[type=submit] {
 	border-style: inset;
 }
 
-med_blue {
+med-blue {
 	font-size: 1.3em;
 	color: blue;
 	font-weight: bold;
 	font-style: normal;
 }
 
-big_red {
+big-red {
 	font-size: 1.7em;
 	color: red;
 	font-weight: bold;
 }
 
-italic_black {
+italic-black {
 	font-size: 1.3em;
 	color: black;
 	font-weight: bold;
 	font-style: italic;
 }
 
-copyright {
+copy-right {
 	font-size: 0.7em;
 	color: darkgrey;
 	font-weight: bold;

--- a/resources/splash.html
+++ b/resources/splash.html
@@ -1,6 +1,17 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="shortcut icon" href="/$imagesdir/splash.jpg" type="image/x-icon">
+<link rel="stylesheet" type="text/css" href="/splash.css">
+
+<title>$gatewayname Hotspot Gateway.</title>
+
 <!--
 Content:
 	Nodogsplash (NDS), by default, serves this splash page (splash.html)
@@ -40,14 +51,14 @@ Available variables:
 	authtarget: $authtarget
 	clientip: $clientip
 	clientmac: $clientmac
+	clientupload: $clientupload
+	clientdownload: $clientdownload
 	gatewaymac: $gatewaymac
 	nclients: $nclients
 	maxclients: $maxclients
 	uptime: $uptime
 	imagesdir: $imagesdir
 	pagesdir: $pagesdir
-	clientupload: $clientupload
-	clientdownload: $clientdownload
 
 Additional Variables that can be passed back via the HTTP get,
 or appended to the query string of the authtarget link:
@@ -55,28 +66,17 @@ or appended to the query string of the authtarget link:
 	password
 -->
 
-<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-<meta http-equiv="Pragma" content="no-cache">
-<meta http-equiv="Expires" content="0">
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-<link rel="shortcut icon" href="/$imagesdir/splash.jpg" type="image/x-icon">
-<link rel="stylesheet" type="text/css" href="/splash.css">
-
-<title>$gatewayname Hotspot Gateway.</title>
-
 </head>
 
 <body>
-<med_blue>$gatewayname Hotspot Gateway.</med_blue>
+<med-blue>$gatewayname Hotspot Gateway.</med-blue>
 <br><br>
 <img src="$imagesdir/splash.jpg" alt="Splash Page: For access to the Internet, please click Continue.">
 <hr>
-<big_red>Welcome!</big_red>
+<big-red>Welcome!</big-red>
 <hr>
 <br>
-<italic_black>For access to the Internet, please tap or click Continue.</italic_black>
+<italic-black>For access to the Internet, please tap or click Continue.</italic-black>
 <br><br>
 <hr>
 
@@ -87,7 +87,7 @@ or appended to the query string of the authtarget link:
 </form>
 	
 <hr>
-<copyright>Copyright &copy; The Nodogsplash Contributors 2004-2018.<br>This software is released under the GNU GPL license.</copyright>
+<copy-right>Copyright &copy; The Nodogsplash Contributors 2004-2018.<br>This software is released under the GNU GPL license.</copy-right>
 
 </body>
 </html>

--- a/resources/status.html
+++ b/resources/status.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-<!--
-Status:
-	The Status page is served to a client if they are already authenticated.
-	This may occur if the client user selects "Back" on the CPD browser
-	screen after they have successfully authenticated.
-
-	The same template variables are available as for the splash page.
--->
 
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 <meta http-equiv="Pragma" content="no-cache">
@@ -21,20 +13,29 @@ Status:
 
 <title>$gatewayname Hotspot Gateway Status</title>
 
+<!--
+Status:
+	The Status page is served to a client if they are already authenticated.
+	This may occur if the client user selects "Back" on the CPD browser
+	screen after they have successfully authenticated.
+
+	The same template variables are available as for the splash page.
+-->
+
 </head>
 
 <body>
 
-<med_blue>$gatewayname Hotspot Gateway.</med_blue>
+<med-blue>$gatewayname Hotspot Gateway.</med-blue>
 <br><br>
 <img src="$imagesdir/splash.jpg" alt="You are already logged in and have access to the Internet.">
 <hr>
-<p><big_red>You are already logged in and have access to the Internet.</big_red></p>
+<p><big-red>You are already logged in and have access to the Internet.</big-red></p>
 <hr>
-<p><italic_black>You can use your Browser, Email and other network Apps as you normally would.</italic_black></p>
+<p><italic-black>You can use your Browser, Email and other network Apps as you normally would.</italic-black></p>
 
 <hr>
-<copyright>Copyright &copy; The Nodogsplash Contributors 2004-2018.<br>This software is released under the GNU GPL license.</copyright>
+<copy-right>Copyright &copy; The Nodogsplash Contributors 2004-2018.<br>This software is released under the GNU GPL license.</copy-right>
 
 </body>
 </html>


### PR DESCRIPTION
Add hyphen to custom tag names in css
Move large comment section to after meta tag lines

Signed-off-by: Rob White <rob@blue-wave.net>