### PR TITLE
Change to 511 redirect instead of 307

### DIFF
--- a/resources/build_libmicrohttpd.sh
+++ b/resources/build_libmicrohttpd.sh
@@ -17,7 +17,7 @@ if [ $# -ne 1 -o "$1" != "--compile"  ] ; then
 fi
 
 if [ -z "$MHD_VERSION" ] ; then
-	MHD_VERSION="0.9.51"
+	MHD_VERSION="0.9.53"
 fi
 unset CFLAGS
 rm -rf /tmp/libmicrohttpd*


### PR DESCRIPTION
Change to 511 redirect -  Network Authentication Required
in place of 307 redirect - Temporary Redirect
In line with RFC6585 Section 6
https://tools.ietf.org/html/rfc6585#section-6

In addition, at some time in the future, this MAY allow port 443 capture, as browsers potentially can see the 511 code and allow the redirect without certificate errors in a secure manner. this however is not implemented yet in any browsers. 


Signed-off-by: Rob White <rob@blue-wave.net>