### PR TITLE
IPv6 firewall fixes

### DIFF
--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -781,6 +781,8 @@ iptables_fw_destroy_mention(
 	const char *mention
 )
 {
+	s_config *config;
+	char *iptables;
 	FILE *p = NULL;
 	char *command = NULL;
 	char *command2 = NULL;
@@ -790,7 +792,9 @@ iptables_fw_destroy_mention(
 
 	debug(LOG_DEBUG, "Checking all mention of %s from %s.%s", mention, table, chain);
 
-	safe_asprintf(&command, "iptables -t %s -L %s -n --line-numbers -v", table, chain);
+	config = config_get_config();
+	iptables = config->ip6 ? "ip6tables" : "iptables";
+	safe_asprintf(&command, "%s -t %s -L %s -n --line-numbers -v", iptables, table, chain);
 
 	if ((p = popen(command, "r"))) {
 		/* Skip first 2 lines */

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -439,6 +439,7 @@ iptables_fw_init(void)
 	/* Create new chains in the mangle table */
 	rc |= iptables_do_command("-t mangle -N " CHAIN_TRUSTED); /* for marking trusted packets */
 	rc |= iptables_do_command("-t mangle -N " CHAIN_BLOCKED); /* for marking blocked packets */
+	rc |= iptables_do_command("-t mangle -N " CHAIN_ALLOWED); /* for marking allowed packets */
 	rc |= iptables_do_command("-t mangle -N " CHAIN_INCOMING); /* for counting incoming packets */
 	rc |= iptables_do_command("-t mangle -N " CHAIN_OUTGOING); /* for marking authenticated packets, and for counting outgoing packets */
 

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -381,6 +381,15 @@ iptables_fw_init(void)
 	LOCK_CONFIG();
 	config = config_get_config();
 	gw_interface = safe_strdup(config->gw_interface); /* must free */
+	
+	/* ip6 addresses must be specified in square brackets like [ffcc:e08::1] */
+	if (config->ip6) {
+		/* TODO: check config-> gw_address doesn't already contain brackets */
+		safe_asprintf(&gw_address, "[%s]", config->gw_address);
+	} else {
+		gw_address = safe_strdup(config->gw_address);    /* must free */
+	}
+	
 	gw_address = safe_strdup(config->gw_address);    /* must free */
 	gw_iprange = safe_strdup(config->gw_iprange);    /* must free */
 	gw_port = config->gw_port;


### PR DESCRIPTION
Another step towards [IPv6 support](https://github.com/nodogsplash/nodogsplash/issues/38). nodogsplash already has some preliminary support for IPv6 in the current `master` code base. The fixes in this pull request solve the problems in `fw_iptables.c` causing nodogsplash immediately shutting down again due to errors in setting ip6tables rules.