### PR TITLE
remaining IPv6 fixes for microhttpd web server

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -71,6 +71,8 @@ typedef enum {
 	oGatewayName,
 	oGatewayInterface,
 	oGatewayIPRange,
+	oGatewayIP,
+	/* TODO: deprecate oGatewayAddress option */
 	oGatewayAddress,
 	oGatewayPort,
 	oFasPort,
@@ -122,6 +124,8 @@ static const struct {
 	{ "gatewayname", oGatewayName },
 	{ "gatewayinterface", oGatewayInterface },
 	{ "gatewayiprange", oGatewayIPRange },
+	{ "gatewayip", oGatewayIP },
+	/* TODO: remove/deprecate gatewayaddress keyword */
 	{ "gatewayaddress", oGatewayAddress },
 	{ "gatewayport", oGatewayPort },
 	{ "fasport", oFasPort },
@@ -196,6 +200,7 @@ config_init(void)
 	config.gw_interface = NULL;
 	config.gw_iprange = safe_strdup(DEFAULT_GATEWAY_IPRANGE);
 	config.gw_address = NULL;
+	config.gw_ip = NULL;
 	config.gw_port = DEFAULT_GATEWAYPORT;
 	config.fas_port = DEFAULT_FASPORT;
 	config.fas_secure_enabled = DEFAULT_FAS_SECURE_ENABLED;
@@ -744,8 +749,10 @@ config_read(const char *filename)
 		case oGatewayIPRange:
 			config.gw_iprange = safe_strdup(p1);
 			break;
+		/* TODO: deprecate oGatewayAddress option */
 		case oGatewayAddress:
-			config.gw_address = safe_strdup(p1);
+		case oGatewayIP:
+			config.gw_ip = safe_strdup(p1);
 			break;
 		case oGatewayPort:
 			if (sscanf(p1, "%u", &config.gw_port) < 1) {

--- a/src/conf.h
+++ b/src/conf.h
@@ -147,7 +147,8 @@ typedef struct {
 	char *gw_name;			/**< @brief Name of the gateway; e.g. its SSID */
 	char *gw_interface;		/**< @brief Interface we will manage */
 	char *gw_iprange;		/**< @brief IP range on gw_interface we will manage */
-	char *gw_address;		/**< @brief Internal IP address for our web server */
+	char *gw_ip;			/**< @brief Internal IP (v4 or v6) for our web server */
+	char *gw_address;		/**< @brief Internal IP with port for our web server */
 	char *gw_mac;			/**< @brief MAC address of the interface we manage */
 	unsigned int gw_port;		/**< @brief Port the webserver will run on */
 	unsigned int fas_port;		/**< @brief Port the fas server will run on */

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -498,7 +498,7 @@ static int authenticated(struct MHD_Connection *connection,
 
 	if (check_authdir_match(url, config->denydir)) {
 		auth_client_deauth(client->id, "client_deauth");
-		snprintf(redirect_to_us, 128, "http://%s/", config->gw_address);
+		snprintf(redirect_to_us, sizeof(redirect_to_us), "http://%s/", config->gw_address);
 		return send_redirect_temp(connection, redirect_to_us);
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 #include <time.h>
 
+#include <arpa/inet.h>
 
 /* for strerror() */
 #include <string.h>
@@ -233,19 +234,29 @@ main_loop(void)
 	}
 
 	/* If we don't have the Gateway IP address, get it. Exit on failure. */
-	if (!config->gw_address) {
+	if (!config->gw_ip) {
 		debug(LOG_DEBUG, "Finding IP address of %s", config->gw_interface);
-		config->gw_address = get_iface_ip(config->gw_interface);
-		if (!config->gw_address) {
+		config->gw_ip = get_iface_ip(config->gw_interface);
+		if (!config->gw_ip) {
 			debug(LOG_ERR, "Could not get IP address information of %s, exiting...", config->gw_interface);
 			exit(1);
 		}
 	}
+
+	/* format gw_address accordingly depending on if gw_ip is v4 or v6 */
+	char buf[16];
+	if (inet_pton(AF_INET, config->gw_ip, buf)) {
+		safe_asprintf(&config->gw_address, "%s:%d", config->gw_ip, config->gw_port);
+	} else if (inet_pton(AF_INET6, config->gw_ip, buf)) {
+		/* add square brackets around IPv6 address */
+		safe_asprintf(&config->gw_address, "[%s]:%d", config->gw_ip, config->gw_port);
+	}
+
 	if ((config->gw_mac = get_iface_mac(config->gw_interface)) == NULL) {
 		debug(LOG_ERR, "Could not get MAC address information of %s, exiting...", config->gw_interface);
 		exit(1);
 	}
-	debug(LOG_NOTICE, "Detected gateway %s at %s (%s)", config->gw_interface, config->gw_address, config->gw_mac);
+	debug(LOG_NOTICE, "Detected gateway %s at %s (%s)", config->gw_interface, config->gw_ip, config->gw_mac);
 
 	/* Initializes the web server */
 	if ((webserver = MHD_start_daemon(
@@ -260,7 +271,7 @@ main_loop(void)
 		exit(1);
 	}
 	/* TODO: set listening socket */
-	debug(LOG_NOTICE, "Created web server on %s:%d", config->gw_address, config->gw_port);
+	debug(LOG_NOTICE, "Created web server on %s", config->gw_address);
 	/*
 		httpdAddCContent(webserver, "/", "", 0, NULL, http_nodogsplash_callback_index);
 		httpdAddCWildcardContent(webserver, config->authdir, NULL, http_nodogsplash_callback_auth);
@@ -270,7 +281,7 @@ main_loop(void)
 
 	/* Make sure fas_remoteip is set. Note: This does not enable FAS. */
 	if (!config->fas_remoteip) {
-		config->fas_remoteip = safe_strdup(config->gw_address);
+		config->fas_remoteip = safe_strdup(config->gw_ip);
 	}
 
 	if (config->fas_port) {

--- a/src/util.c
+++ b/src/util.c
@@ -437,7 +437,7 @@ ndsctl_status(FILE *fp)
 	fprintf(fp, "Gateway Name: %s\n", config->gw_name);
 	fprintf(fp, "Managed interface: %s\n", config->gw_interface);
 	fprintf(fp, "Managed IP range: %s\n", config->gw_iprange);
-	fprintf(fp, "Server listening: %s:%d\n", config->gw_address, config->gw_port);
+	fprintf(fp, "Server listening: http://%s\n", config->gw_address);
 
 	if (config->binauth) {
 		fprintf(fp, "Binauth Script: %s\n", config->binauth);

--- a/src/util.h
+++ b/src/util.h
@@ -94,5 +94,14 @@ unsigned short rand16(void);
 	debug(LOG_DEBUG, "wd_gethostbyname() unlocked"); \
 } while (0)
 
+/*
+ * @brief Maximum <host>:<port> length (IPv6)
+ * - INET6_ADDRSTRLEN: 46 (45 chars + term. Null byte)
+ * - square brackets around IPv6 address: 2 ('[' and ']')
+ * - port separator character: 1 (':')
+ * - max port number: 5 (2^16 = 65536)
+ * Total: 54 chars
+ **/
+#define MAX_HOSTPORTLEN ( INET6_ADDRSTRLEN + sizeof("[]:65536")-1 )
 
 #endif /* _UTIL_H_ */


### PR DESCRIPTION
Renamed `config->gw_address` to `config->gw_ip` as discussed in https://github.com/nodogsplash/nodogsplash/issues/38.
Fixed too small buffer for IPv6 in `our_host` variable in `is_foreign_hosts()` and `is_splashpage()`