### PR TITLE
Copy OpenWrt specific files

### DIFF
--- a/openwrt/nodogsplash/Makefile
+++ b/openwrt/nodogsplash/Makefile
@@ -41,7 +41,6 @@ define Package/nodogsplash/description
 endef
 
 define Package/nodogsplash/install
-	$(CP) ./files/* $(1)/
 
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nodogsplash $(1)/usr/bin/
@@ -52,6 +51,10 @@ define Package/nodogsplash/install
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.css $(1)/etc/nodogsplash/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/status.html $(1)/etc/nodogsplash/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/nodogsplash/htdocs/images/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/config/nodogsplash $(1)/etc/config/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/init.d/nodogsplash $(1)/etc/init.d/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/uci-defaults/40_nodogsplash $(1)/etc/uci-defaults/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
 endef
 
 define Package/nodogsplash/postrm


### PR DESCRIPTION
Makefile: Openwrt specific files copied from PKG_SOURCE

This makefile should then also be used in openwrt-packages.
Then for an official release of OpenWrt package only the PKG_VERSION, PKG_RELEASE and PKG_HASH need to be updated with no access to the /nodogsplash/nodogsplash/ repository being required by a maintainer.

Signed-off-by: Rob White <rob@blue-wave.net>