### PR TITLE
WIP: Per-user traffic quota (not bandwith, but total transfer limit)

### DIFF
--- a/src/fw_iptables.h
+++ b/src/fw_iptables.h
@@ -90,4 +90,6 @@ int iptables_unallow_mac(const char mac[]);
 int iptables_trust_mac(const char mac[]);
 int iptables_untrust_mac(const char mac[]);
 
+void iptables_block_if_counter_exceeded(t_client *client);
+
 #endif /* _IPTABLES_H_ */


### PR DESCRIPTION
I am starting to work on the implementation of total transfer quota on a per-user basis. This obviously is by no means anywhere near ready to be merged. I am opening this pull request in order to ask a few questions during development.

First question: what would be the right thing to do if the user exceeds their quota? Right now, i am calling `iptables_fw_deauthenticate(client)`, just because it is the only function that accepts a `t_client` argument and sounds like it would lock them out. I clearly do not have an understanding of how everything works, yet. So a small hint would be appreciated, in order to get me going into the right direction.

I am also thankful for any other hints supporting my current goal ;)

Thanks a lot in advance!