### PR TITLE
Include PreAuth Login script in package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ install:
 	cp resources/splash.css $(DESTDIR)/etc/nodogsplash/htdocs/
 	cp resources/status.html $(DESTDIR)/etc/nodogsplash/htdocs/
 	cp resources/splash.jpg $(DESTDIR)/etc/nodogsplash/htdocs/images/
+	cp forward_authentication_service/PreAuth/demo-preauth.sh $(DESTDIR)/etc/nodogsplash/login.sh
 
 checkastyle:
 	@command -v astyle >/dev/null 2>&1 || \

--- a/openwrt/nodogsplash/files/etc/config/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/config/nodogsplash
@@ -16,9 +16,18 @@ config nodogsplash
   # Use plain configuration file
   #option config '/etc/nodogsplash/nodogsplash.conf'
 
-  # Use this option to set the device nogogsplash will bind to.
+  # Use this option to set the device nodogsplash will bind to.
   # The value may be an interface section in /etc/config/network or a device name such as br-lan.
   option gatewayinterface 'br-lan'
+
+  # GatewayPort
+  # Default: 2050
+  #
+  # Nodogsplash's own http server uses gateway address as its IP address.
+  # The port it listens to at that IP can be set here; default is 2050.
+  #
+  #option gatewayport '2050'
+
 
   option gatewayname 'OpenWrt Nodogsplash'
   option maxclients '250'
@@ -87,6 +96,12 @@ config nodogsplash
   #option fas_secure_enabled '0'
 
   # Enable PreAuth Support.
+  #
+  # A simple login script is provided in the package.
+  # This generates a login page asking for usename and email address.
+  # User logins are recorded in the log file /tmp/ndslog.log
+  # Details of how the script works are contained in comments in the script itself.
+  #
   # PreAuth support allows FAS to call a local program or script with html served by NDS
   # If set, a program/script is called by the NDS FAS handler when:
   # 1. fasremopteip is not set,
@@ -106,7 +121,13 @@ config nodogsplash
   # It must also obtain the client token using ndsctl (or the original query string if fas_secure_enabled=0)
   # for NDS authentication when calling /nodogsplash_auth/
   #
-  #option preauth '/bin/mypreauth.sh'
+
+  # Enable username/emailaddress login.
+  # Note: fasport must be set to the same value as gatewayport (default = 2050)
+  # Enable by uncommenting the following three lines
+  #option fasport '2050'
+  #option faspath '/nodogsplash_preauth/'
+  #option preauth '/usr/lib/nodogsplash/login.sh'
 
   # Your router may have several interfaces, and you
   # probably want to keep them private from the gatewayinterface.

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -372,6 +372,11 @@ FirewallRuleSet users-to-router {
 # fas_secure_enabled 0
 
 # Enable PreAuth Support.
+# A simple login script is provided in the package.
+# This generates a login page asking for usename and email address.
+# User logins are recorded in the log file /tmp/ndslog.log
+# Details of how the script works are contained in comments in the script itself.
+#
 # PreAuth support allows FAS to call a local program or script with html served by NDS
 # If set, a program/script is called by the NDS FAS handler when:
 # 1. fasremopteip is not set,
@@ -391,7 +396,19 @@ FirewallRuleSet users-to-router {
 # It must also obtain the client token using ndsctl (or the original query string if fas_secure_enabled=0)
 # for NDS authentication when calling /nodogsplash_auth/
 #
-# preauth '/bin/mypreauth.sh'
+
+# Enable username/emailaddress login.
+#
+# Note: fasport must be set to the same value as GateWayport (default = 2050)
+# Enable by uncommenting the following two lines
+# fasport '2050'
+# faspath '/nodogsplash_preauth/'
+#
+# and this one for OpenWrt
+# preauth '/usr/lib/nodogsplash/login.sh'
+#
+# or this one for Debian and other Linux distributions
+# preauth '/etc/nodogsplash/login.sh'
 
 # Parameter: BinAuth
 #


### PR DESCRIPTION
Include in the package a fully functional login script for preauth.
Config file(s) are updated to include pre configured but commented out parameters to enable.
The login script generates dynamic html for NDS to serve using MHD. The login page asks for a username and email address. User logins are recorded in the file /tmp/ndslog.log

Differences between OpenWrt and Debian (and other Linux distributions) are taken into account.

Tested on OpenWrt Snapshot

`Signed-off-by: Rob White <rob@blue-wave.net>`