### PR TITLE
 Validate Fasremoteip and Fasport 

### DIFF
--- a/debian/doc/nodogsplash.1
+++ b/debian/doc/nodogsplash.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NODOGSPLASH" "1" "April 05, 2019" "3.3.1-beta" "nodogsplash"
+.TH "NODOGSPLASH" "1" "April 22, 2019" "3.3.2-beta" "nodogsplash"
 .SH NAME
 nodogsplash \- nodogsplash Documentation
 .
@@ -281,14 +281,17 @@ for v0.9.
 .sp
 v2 was developed before version v1 was released. In v2 the http code was replaced by libmicrohttpd and the template engine was rewritten. Many features became defunct because of this procedure.
 .sp
-v3 cleans up the source code and adds two major new features,
+v3 cleans up the source code and adds three major new features,
 .INDENT 0.0
 .INDENT 3.5
-FAS enabling an external forwarding authentication service to be called,
-.sp
-and
-.sp
-binauth, enabling an external script to be called for simple username/password authentication as well as doing post authentication processing such as setting session durations. This is similar to the old binvoucher feature, but more flexible.
+.INDENT 0.0
+.IP 1. 3
+\fBFAS\fP, a forwarding authentication service. FAS supports development of "Credential Verification" running on any dynamic web serving platform, on the same device as Nodogsplash, on another device on the local network, or on an Internet hosted web server.
+.IP 2. 3
+\fBPreAuth\fP, an implementation of FAS running on the same device as Nodogsplash and using Nogogsplash\(aqs own web server to generate dynamic web pages. Any scripting language or even a compiled application program can be used. This has the advantage of not requiring the resources of a separate web server.
+.IP 3. 3
+\fBBinAuth\fP, enabling an external script to be called for simple username/password authentication as well as doing post authentication processing such as setting session durations. This is similar to the old binvoucher feature, but more flexible.
+.UNINDENT
 .UNINDENT
 .UNINDENT
 .sp
@@ -459,6 +462,13 @@ Nodogsplash (NDS) supports external (to NDS) authentication service via simple c
 \fBfas_secure_enable\fP\&. If set to "1", authaction and the client token are not revealed and it is the responsibility of the FAS to request the token from NDSCTL. If set to "0", the client token is sent to the FAS in clear text in the query string of the redirect along with authaction and redir.
 .UNINDENT
 .UNINDENT
+.sp
+\fBNOTE:\fP
+.INDENT 0.0
+.INDENT 3.5
+FAS (and Preauth/FAS) enables pre authentication processing. NDS authentication is the process that NDS uses to allow a client device to access the Internet through the Firewall. In contrast, Forward Authentication is a process of "Credential Verification", after which FAS, if the verification process is successful, passes the client token to NDS for access to the Internet to be granted.
+.UNINDENT
+.UNINDENT
 .SS Using FAS
 .sp
 \fBNote\fP:
@@ -472,8 +482,7 @@ Typically, the FAS service will be written in PHP or any other language that can
 FAS can then provide an action form for the client, typically requesting login, or self account creation for login.
 .sp
 The FAS can be on the same device as NDS, on the same local area network as NDS, or on an Internet hosted web server.
-.sp
-\fISecurity\fP\&.
+.SS Security
 .sp
 \fBIf FAS Secure is enabled\fP (fas_secure_enabled = 1, the default), NDS will supply only the gateway name, the client IP address and the originally requested URL in the query string in the redirect to FAS.
 .sp
@@ -532,15 +541,19 @@ A FAS service will run quite well on uhttpd (the web server that serves Luci) on
 For this reason a device with a minimum of 8MB flash and 64MB ram is recommended.
 .sp
 \fBRunning on uhttpd with PHP\fP:
+.sp
+Although port 80 is the default for uhttpd, it is reserved for Captive Portal Detection so cannot be used for FAS. uhttpd can however be configured to operate on more than one port. We will use port 2080 in this example.
 .INDENT 0.0
 .INDENT 3.5
 Install the modules php7 and php7\-cgi on OpenWrt for a simple example. Further modules may be required depending on your requirements.
 .UNINDENT
 .UNINDENT
 .sp
-To enable php in uhttpd you must add the line:
+To enable FAS with php in uhttpd you must add the lines:
 .INDENT 0.0
 .INDENT 3.5
+\fBlist listen_http    0.0.0.0:2080\fP
+.sp
 \fBlist interpreter ".php=/usr/bin/php\-cgi"\fP
 .UNINDENT
 .UNINDENT
@@ -552,7 +565,7 @@ The two important NDS options to set will be:
 .INDENT 3.5
 .INDENT 0.0
 .IP 1. 3
-fasport. By default this will be port 80 for uhttpd
+fasport. We will use port 2080 for uhttpd
 .IP 2. 3
 faspath. Set to, for example, /myfas/fas.php,
 your FAS files being placed in /www/myfas/
@@ -563,12 +576,12 @@ your FAS files being placed in /www/myfas/
 \fBNote 1\fP:
 .INDENT 0.0
 .INDENT 3.5
-A typical Internet hosted Apache/PHP shared server will be set up to serve multiple domain names.
+A typical Internet hosted Apache/PHP \fBshared\fP server will be set up to serve multiple domain names.
 .sp
 To access yours, use:
 .INDENT 0.0
 .INDENT 3.5
-fasremoteip = the ip address of the remote server
+fasremoteip = the \fBip address\fP of the remote server
 .sp
 and, for example,
 .sp

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -10,13 +10,13 @@ for v0.9.
 
 v2 was developed before version v1 was released. In v2 the http code was replaced by libmicrohttpd and the template engine was rewritten. Many features became defunct because of this procedure.
 
-v3 cleans up the source code and adds two major new features,
+v3 cleans up the source code and adds three major new features,
 
- FAS enabling an external forwarding authentication service to be called,
+ 1. **FAS**, a forwarding authentication service. FAS supports development of "Credential Verification" running on any dynamic web serving platform, on the same device as Nodogsplash, on another device on the local network, or on an Internet hosted web server.
 
- and 
+ 2. **PreAuth**, an implementation of FAS running on the same device as Nodogsplash and using Nogogsplash's own web server to generate dynamic web pages. Any scripting language or even a compiled application program can be used. This has the advantage of not requiring the resources of a separate web server.
 
- binauth, enabling an external script to be called for simple username/password authentication as well as doing post authentication processing such as setting session durations. This is similar to the old binvoucher feature, but more flexible.
+ 3. **BinAuth**, enabling an external script to be called for simple username/password authentication as well as doing post authentication processing such as setting session durations. This is similar to the old binvoucher feature, but more flexible.
 
 In addition, in v3, the ClientTimeout setting was split into PreauthIdleTimeout and AuthIdleTimeout and for the ClientForceTimeout setting, SessionTimeout is now used instead.
 

--- a/docs/source/fas.rst
+++ b/docs/source/fas.rst
@@ -12,6 +12,9 @@ These options are:
  3. **faspath**. This is the path to the login page on the FAS.
  4. **fas_secure_enable**. If set to "1", authaction and the client token are not revealed and it is the responsibility of the FAS to request the token from NDSCTL. If set to "0", the client token is sent to the FAS in clear text in the query string of the redirect along with authaction and redir.
 
+.. note::
+ FAS (and Preauth/FAS) enables pre authentication processing. NDS authentication is the process that NDS uses to allow a client device to access the Internet through the Firewall. In contrast, Forward Authentication is a process of "Credential Verification", after which FAS, if the verification process is successful, passes the client token to NDS for access to the Internet to be granted.
+
 
 Using FAS
 *********
@@ -28,7 +31,8 @@ FAS can then provide an action form for the client, typically requesting login, 
 
 The FAS can be on the same device as NDS, on the same local area network as NDS, or on an Internet hosted web server.
 
-*Security*.
+Security
+********
 
 **If FAS Secure is enabled** (fas_secure_enabled = 1, the default), NDS will supply only the gateway name, the client IP address and the originally requested URL in the query string in the redirect to FAS.
 
@@ -91,9 +95,13 @@ For this reason a device with a minimum of 8MB flash and 64MB ram is recommended
 
 **Running on uhttpd with PHP**:
 
+Although port 80 is the default for uhttpd, it is reserved for Captive Portal Detection so cannot be used for FAS. uhttpd can however be configured to operate on more than one port. We will use port 2080 in this example.
+
  Install the modules php7 and php7-cgi on OpenWrt for a simple example. Further modules may be required depending on your requirements.
 
-To enable php in uhttpd you must add the line:
+To enable FAS with php in uhttpd you must add the lines:
+
+  ``list listen_http	0.0.0.0:2080``
 
   ``list interpreter ".php=/usr/bin/php-cgi"``
 
@@ -101,18 +109,18 @@ to the /etc/config/uhttpd file in the config uhttpd 'main' or first section.
 
 The two important NDS options to set will be:
 
- 1. fasport. By default this will be port 80 for uhttpd
+ 1. fasport. We will use port 2080 for uhttpd
 
  2. faspath. Set to, for example, /myfas/fas.php,
     your FAS files being placed in /www/myfas/
 
 **Note 1**:
 
- A typical Internet hosted Apache/PHP shared server will be set up to serve multiple domain names.
+ A typical Internet hosted Apache/PHP **shared** server will be set up to serve multiple domain names.
 
  To access yours, use:
 
-  fasremoteip = the ip address of the remote server
+  fasremoteip = the **ip address** of the remote server
 
   and, for example,
 

--- a/openwrt/nodogsplash/files/etc/config/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/config/nodogsplash
@@ -74,18 +74,31 @@ config nodogsplash
   # Enable Forwarding Authentication Service (FAS)
   # If set redirection is changed from splash.html to a FAS (provided by the system administrator)
   # The value is the IP port number of the FAS
+  # Note: if FAS is running locally (ie fasremoteip is NOT set), port 80 cannot be used.
+  #
+  # Typical Remote Shared Hosting Example:
   #option fasport '80'
+  #
+  # Typical Locally Hosted example (ie fasremoteip not set):
+  #option fasport '2080'
 
   # Option: fasremoteip
   # Default: GatewayAddress (the IP of NDS)
   # If set, this is the remote ip address of the FAS.
+  #
+  # Typical Remote Shared Hosting Example:
   #option fasremoteip '46.32.240.41'
 
   # Option: faspath
   # Default: /
   # This is the path from the FAS Web Root to the FAS login page
   # (not the file system root).
+  #
+  # Typical Remote Shared Hosting Example:
   #option faspath '/onboard-wifi.net/nodog/fas.php'
+  #
+  # Typical Locally Hosted example (ie fasremoteip not set):
+  #option faspath '/nodog/fas.php'
 
   # Option: fas_secure_enabled
   # Default: 1

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -343,14 +343,21 @@ FirewallRuleSet users-to-router {
 # Enable Forwarding Authentication Service (FAS)
 # If set redirection is changed from splash.html to a FAS (provided by the system administrator)
 # The value is the IP port number of the FAS
+# Note: if FAS is running locally (ie fasremoteip is NOT set), port 80 cannot be used
 #
+# Typical remote Hosted Example:
+# fasport 80
+#
+# Typical Locally Hosted Example:
 # fasport 2080
+
 
 # Parameter: fasremoteip
 # Default: GatewayAddress (the IP of NDS)
 #
 # If set, this is the remote ip address of the FAS.
 #
+# Typical Locally Hosted example (ie fasremoteip not set):
 # fasremoteip 46.32.240.41
 
 # Parameter: faspath
@@ -359,6 +366,10 @@ FirewallRuleSet users-to-router {
 # This is the path from the FAS Web Root to the FAS login page
 # (not the file system root).
 #
+# Typical Shared Hosting example:
+# faspath '/onboard-wifi.net/nodog/fas.php'
+#
+# Typical Locally Hosted example (ie fasremoteip not set):
 # faspath /nodog/fas.php
 
 # Parameter: fas_secure_enabled

--- a/src/conf.c
+++ b/src/conf.c
@@ -756,7 +756,8 @@ config_read(const char *filename)
 			break;
 		case oDebugLevel:
 			if (sscanf(p1, "%d", &config.debuglevel) < 1 || config.debuglevel < LOG_EMERG || config.debuglevel > LOG_DEBUG) {
-				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s. Valid debuglevel %d..%d", p1, s, linenum, filename, LOG_EMERG, LOG_DEBUG);
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s. Valid debuglevel %d..%d",
+					p1, s, linenum, filename, LOG_EMERG, LOG_DEBUG);
 				debug(LOG_ERR, "Exiting...");
 				exit(-1);
 			}
@@ -989,7 +990,7 @@ config_read(const char *filename)
 
 	if (config.fas_remoteip) {
 		if (validateIP4Dotted(config.fas_remoteip) == 1) {
-			debug(LOG_ERR, "fasremoteip - %s - is a valid IPv4 address...", config.fas_remoteip);
+			debug(LOG_INFO, "fasremoteip - %s - is a valid IPv4 address...", config.fas_remoteip);
 		} else {
 			debug(LOG_ERR, "fasremoteip - %s - is NOT a valid IPv4 address format...", config.fas_remoteip);
 			debug(LOG_ERR, "Exiting...");

--- a/src/conf.c
+++ b/src/conf.c
@@ -53,7 +53,7 @@ int validateIP4Dotted(const char *ip4addr)
 
 	char tail[16];
 	tail[0] = 0;
-
+	int i = 0;
 	unsigned int d[4];
 	int c = sscanf(ip4addr, "%3u.%3u.%3u.%3u%s", &d[0], &d[1], &d[2], &d[3], tail);
 
@@ -61,7 +61,7 @@ int validateIP4Dotted(const char *ip4addr)
 		return 0;
 	}
 
-	for (int i = 0; i < 4; i++) {
+	for (i = 0; i < 4; i++) {
 		if (d[i] > 255) {
 			return 0;
 		}


### PR DESCRIPTION
 1. fasremoteip must be a dot format ipv4 address. The config value is now validated and NDS terminates with a console error message if validation fails.
 2. Version 3.3.0 introduced improvements towards usable IPv6 support. This however induces a "too many redirects error" in device CPD if port 80 is used for FAS in the case of FAS running locally on the NDS device. Fasport is now checked for port 80 and local FAS, and NDS terminates with a console error message if these conditions are found.
 3. The config file has been updated to reflect points 1 and 2.
 4. Documentation has been updated to reflect points 1 and 2.

Compile tested on OpenWrt SDK, ath79 platform.

Run tested on gl-inet ar300m-16

Signed-off-by: Rob White `<rob@blue-wave.net>`