### PR TITLE
remove unused pagesdir and imagesdir

### DIFF
--- a/openwrt/nodogsplash/files/etc/init.d/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/init.d/nodogsplash
@@ -141,7 +141,7 @@ generate_uci_config() {
 
   for option in preauth binauth fasport fasremoteip faspath fas_secure_enabled \
     daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
-    gatewayaddress gatewayport webroot splashpage statuspage imagesdir pagesdir \
+    gatewayaddress gatewayport webroot splashpage statuspage \
     redirecturl sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue trafficcontrol downloadlimit uploadlimit \
     syslogfacility ndsctlsocket fw_mark_authenticated \

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -322,14 +322,6 @@ FirewallRuleSet users-to-router {
 #
 # GatewayIPRange 0.0.0.0/0
 
-# Parameter: ImagesDir
-# Default: images
-#
-# Set the directory from which images are served.
-# Use $imagesdir in HTML files to reference this directory.
-#
-# ImagesDir images
-
 # Parameter: DebugLevel
 # Default: 5
 #

--- a/resources/splash.html
+++ b/resources/splash.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<link rel="shortcut icon" href="/$imagesdir/splash.jpg" type="image/x-icon">
+<link rel="shortcut icon" href="/images/splash.jpg" type="image/x-icon">
 <link rel="stylesheet" type="text/css" href="/splash.css">
 
 <title>$gatewayname Hotspot Gateway.</title>
@@ -28,9 +28,6 @@ Content:
 		Prohibit downloading of external files
 			(including .css and .js).
 		Prohibit the execution of javascript.
-
-	Also, note that any images you reference should reside in the
-	subdirectory that is defined by $imagesdir (default: "images").
 
 Authentication:
 	A client is authenticated on submitting an HTTP form, method=get,
@@ -57,8 +54,6 @@ Available variables:
 	nclients: $nclients
 	maxclients: $maxclients
 	uptime: $uptime
-	imagesdir: $imagesdir
-	pagesdir: $pagesdir
 
 Additional Variables that can be passed back via the HTTP get,
 or appended to the query string of the authtarget link:
@@ -73,7 +68,7 @@ or appended to the query string of the authtarget link:
 <med-blue>$gatewayname Hotspot Gateway.</med-blue>
 <div class="insert">
 <br>
-<img src="$imagesdir/splash.jpg" alt="Splash Page: For access to the Internet, please click Continue.">
+<img src="/images/splash.jpg" alt="Splash Page: For access to the Internet, please click Continue.">
 <hr>
 <big-red>Welcome!</big-red>
 <hr>

--- a/resources/status.html
+++ b/resources/status.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<link rel="shortcut icon" href="/$imagesdir/splash.jpg" type="image/x-icon">
+<link rel="shortcut icon" href="/images/splash.jpg" type="image/x-icon">
 <link rel="stylesheet" type="text/css" href="/splash.css">
 
 <title>$gatewayname Hotspot Gateway Status</title>
@@ -29,7 +29,7 @@ Status:
 <med-blue>$gatewayname Hotspot Gateway.</med-blue>
 <div class="insert">
 <br>
-<img src="$imagesdir/splash.jpg" alt="You are already logged in and have access to the Internet.">
+<img src="/images/splash.jpg" alt="You are already logged in and have access to the Internet.">
 <hr>
 <p><big-red>You are already logged in and have access to the Internet.</big-red></p>
 <hr>

--- a/src/conf.c
+++ b/src/conf.c
@@ -83,8 +83,6 @@ typedef enum {
 	oWebRoot,
 	oSplashPage,
 	oStatusPage,
-	oImagesDir,
-	oPagesDir,
 	oRedirectURL,
 	oPreauthIdleTimeout,
 	oAuthIdleTimeout,
@@ -136,8 +134,6 @@ static const struct {
 	{ "webroot", oWebRoot },
 	{ "splashpage", oSplashPage },
 	{ "statuspage", oStatusPage },
-	{ "imagesdir", oImagesDir },
-	{ "pagesdir", oPagesDir },
 	{ "redirectURL", oRedirectURL },
 	{ "preauthidletimeout", oPreauthIdleTimeout },
 	{ "authidletimeout", oAuthIdleTimeout },
@@ -211,8 +207,6 @@ config_init(void)
 	config.webroot = safe_strdup(DEFAULT_WEBROOT);
 	config.splashpage = safe_strdup(DEFAULT_SPLASHPAGE);
 	config.statuspage = safe_strdup(DEFAULT_STATUSPAGE);
-	config.imagesdir = safe_strdup(DEFAULT_IMAGESDIR);
-	config.pagesdir = safe_strdup(DEFAULT_PAGESDIR);
 	config.authdir = safe_strdup(DEFAULT_AUTHDIR);
 	config.denydir = safe_strdup(DEFAULT_DENYDIR);
 	config.preauthdir = safe_strdup(DEFAULT_PREAUTHDIR);
@@ -836,12 +830,6 @@ config_read(const char *filename)
 			break;
 		case oStatusPage:
 			config.statuspage = safe_strdup(p1);
-			break;
-		case oImagesDir:
-			config.imagesdir = safe_strdup(p1);
-			break;
-		case oPagesDir:
-			config.pagesdir = safe_strdup(p1);
 			break;
 		case oRedirectURL:
 			config.redirectURL = safe_strdup(p1);

--- a/src/conf.h
+++ b/src/conf.h
@@ -65,8 +65,6 @@
 #define DEFAULT_WEBROOT "/etc/nodogsplash/htdocs"
 #define DEFAULT_SPLASHPAGE "splash.html"
 #define DEFAULT_STATUSPAGE "status.html"
-#define DEFAULT_IMAGESDIR "images"
-#define DEFAULT_PAGESDIR "pages"
 #define DEFAULT_AUTHDIR "nodogsplash_auth"
 #define DEFAULT_DENYDIR "nodogsplash_deny"
 #define DEFAULT_PREAUTHDIR "nodogsplash_preauth"
@@ -161,8 +159,6 @@ typedef struct {
 	char *webroot;			/**< @brief Directory containing splash pages, etc. */
 	char *splashpage;		/**< @brief Name of main splash page */
 	char *statuspage;		/**< @brief Name of info status page */
-	char *imagesdir;		/**< @brief Subdir of webroot containing .png .gif files etc */
-	char *pagesdir;			/**< @brief Subdir of webroot containing other .html files */
 	char *redirectURL;		/**< @brief URL to direct client to after authentication */
 	char *authdir;			/**< @brief Notional relative dir for authentication URL */
 	char *denydir;			/**< @brief Notional relative dir for denial URL */

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -1026,8 +1026,6 @@ static void replace_variables(
 	char *denyaction = NULL;
 	char *authaction = NULL;
 	char *authtarget = NULL;
-	char *imagesdir = NULL;
-	char *pagesdir = NULL;
 
 	sprintf(clientupload, "%llu", client->counters.outgoing);
 	sprintf(clientdownload, "%llu", client->counters.incoming);
@@ -1041,8 +1039,6 @@ static void replace_variables(
 	safe_asprintf(&authaction, "http://%s/%s/", config->gw_address, config->authdir);
 	safe_asprintf(&authtarget, "http://%s/%s/?tok=%s&amp;redir=%s",
 		config->gw_address, config->authdir, client->token, redirect_url);
-	safe_asprintf(&pagesdir, "/%s", config->pagesdir);
-	safe_asprintf(&imagesdir, "/%s", config->imagesdir);
 
 	struct template vars[] = {
 		{"authaction", authaction},
@@ -1054,8 +1050,6 @@ static void replace_variables(
 		{"clientdownload", clientdownload},
 		{"gatewaymac", config->gw_mac},
 		{"gatewayname", config->gw_name},
-		{"imagesdir", imagesdir},
-		{"pagesdir", pagesdir},
 		{"maxclients", maxclients},
 		{"nclients", nclients},
 		{"redir", redirect_url},
@@ -1071,8 +1065,6 @@ static void replace_variables(
 	free(denyaction);
 	free(authaction);
 	free(authtarget);
-	free(pagesdir);
-	free(imagesdir);
 }
 
 static int show_templated_page(struct MHD_Connection *connection, t_client *client, const char *page)


### PR DESCRIPTION
Both variables are not used anymore.

Iirc, the original purpose was to have explicit subfolders so to avoid path name clashes when the intercepted page was loaded. Otherwise, splash page content might be shown in the intercepted page.