### PR TITLE
make debuglevel platform independent

### DIFF
--- a/src/commandline.c
+++ b/src/commandline.c
@@ -48,12 +48,12 @@ usage(void)
 		"\n"
 		"  -c <path>   Use configuration file\n"
 		"  -f          Run in foreground\n"
-		"  -d <level>  Debug level (0-9)\n"
+		"  -d <level>  Debug level (%d-%d)\n"
 		"  -s          Log to syslog\n"
 		"  -w <path>   Ndsctl socket path\n"
 		"  -h          Print this help\n"
 		"  -v          Print version\n"
-		"\n"
+		"\n", DEBUGLEVEL_MIN, DEBUGLEVEL_MAX
 	);
 }
 
@@ -92,8 +92,9 @@ void parse_commandline(int argc, char **argv)
 			break;
 
 		case 'd':
-			if (optarg) {
-				set_log_level(atoi(optarg));
+			if (set_debuglevel(optarg)) {
+				printf("Could not set debuglevel to %d\n", atoi(optarg));
+				exit(1);
 			}
 			break;
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -735,11 +735,14 @@ config_read(const char *filename)
 			}
 			break;
 		case oDebugLevel:
-			if (sscanf(p1, "%d", &config.debuglevel) < 1 || config.debuglevel < LOG_EMERG || config.debuglevel > LOG_DEBUG) {
-				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s. Valid debuglevel %d..%d",
-					p1, s, linenum, filename, LOG_EMERG, LOG_DEBUG);
+			if (sscanf(p1, "%d", &config.debuglevel) < 1 || config.debuglevel < DEBUGLEVEL_MIN) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s. Valid levels are %d...%d.",
+					p1, s, linenum, filename, DEBUGLEVEL_MIN, DEBUGLEVEL_MAX);
 				debug(LOG_ERR, "Exiting...");
 				exit(1);
+			} else if (config.debuglevel > DEBUGLEVEL_MAX) {
+				config.debuglevel = DEBUGLEVEL_MAX;
+				debug(LOG_WARNING, "Invalid debug level. Set to maximum.");
 			}
 			break;
 		case oMaxClients:
@@ -1377,15 +1380,29 @@ void parse_allowed_mac_list(const char ptr[])
 	free(ptrcopyptr);
 }
 
-
-
 /** Set the debug log level.  See syslog.h
  *  Return 0 on success.
  */
-int set_log_level(int level)
+int set_debuglevel(const char opt[])
 {
-	config.debuglevel = level;
-	return 0;
+	char *end;
+
+	if (opt == NULL || strlen(opt) == 0) {
+		return 1;
+	}
+
+	// parse number
+	int level = strtol(opt, &end, 10);
+	if (end != (opt + strlen(opt))) {
+		return 1;
+	}
+
+	if (level >= DEBUGLEVEL_MIN && level <= DEBUGLEVEL_MAX) {
+		config.debuglevel = level;
+		return 0;
+	} else {
+		return 1;
+	}
 }
 
 /** Verifies if the configuration is complete and valid.  Terminates the program if it isn't */

--- a/src/conf.h
+++ b/src/conf.h
@@ -49,7 +49,7 @@
 #define DEFAULT_CONFIGFILE SYSCONFDIR"/nodogsplash/nodogsplash.conf"
 #endif
 #define DEFAULT_DAEMON 1
-#define DEFAULT_DEBUGLEVEL LOG_WARNING
+#define DEFAULT_DEBUGLEVEL 1
 #define DEFAULT_MAXCLIENTS 20
 #define DEFAULT_GATEWAY_IPRANGE "0.0.0.0/0"
 #define DEFAULT_GATEWAYNAME "NoDogSplash"
@@ -243,7 +243,7 @@ int check_ip_format(const char[]);
 int check_mac_format(const char[]);
 
 /** config API, used in commandline.c */
-int set_log_level(int);
+int set_debuglevel(const char[]);
 
 #define LOCK_CONFIG() do { \
 	debug(LOG_DEBUG, "Locking config"); \

--- a/src/debug.h
+++ b/src/debug.h
@@ -28,6 +28,9 @@
 
 #include <syslog.h>
 
+#define DEBUGLEVEL_MIN 0
+#define DEBUGLEVEL_MAX 3
+
 /** @brief Used to output messages.
  *The messages will include the finlname and line number, and will be sent to syslog if so configured in the config file
  */

--- a/src/ndsctl.c
+++ b/src/ndsctl.c
@@ -75,7 +75,7 @@ usage(void)
 		"  unallow mac         Unallow the given MAC address\n"
 		"  trust mac           Trust the given MAC address\n"
 		"  untrust mac         Untrust the given MAC address\n"
-		"  loglevel n          Set logging level to n\n"
+		"  debuglevel n        Set debug level to n\n"
 		"\n"
 	);
 }
@@ -85,7 +85,7 @@ static struct argument arguments[] = {
 	{"json", NULL, NULL},
 	{"status", NULL, NULL},
 	{"stop", NULL, NULL},
-	{"loglevel", "Log level set to %s.\n", "Failed to set log level to %s.\n"},
+	{"debuglevel", "Debug level set to %s.\n", "Failed to set debug level to %s.\n"},
 	{"deauth", "Client %s deauthenticated.\n", "Client %s not found.\n"},
 	{"auth", "Client %s authenticated.\n", "Failed to authenticate client %s.\n"},
 	{"block", "MAC %s blocked.\n", "Failed to block MAC %s.\n"},

--- a/src/ndsctl_thread.c
+++ b/src/ndsctl_thread.c
@@ -70,7 +70,7 @@ static void ndsctl_trust(FILE *fp, char *arg);
 static void ndsctl_untrust(FILE *fp, char *arg);
 static void ndsctl_auth(FILE *fp, char *arg);
 static void ndsctl_deauth(FILE *fp, char *arg);
-static void ndsctl_loglevel(FILE *fp, char *arg);
+static void ndsctl_debuglevel(FILE *fp, char *arg);
 
 static int socket_set_non_blocking(int sockfd);
 
@@ -275,8 +275,8 @@ ndsctl_handler(int fd)
 		ndsctl_auth(fp, (request + 5));
 	} else if (strncmp(request, "deauth", 6) == 0) {
 		ndsctl_deauth(fp, (request + 7));
-	} else if (strncmp(request, "loglevel", 8) == 0) {
-		ndsctl_loglevel(fp, (request + 9));
+	} else if (strncmp(request, "debuglevel", 10) == 0) {
+		ndsctl_debuglevel(fp, (request + 11));
 	}
 
 	if (!done) {
@@ -460,24 +460,22 @@ ndsctl_untrust(FILE *fp, char *arg)
 }
 
 static void
-ndsctl_loglevel(FILE *fp, char *arg)
+ndsctl_debuglevel(FILE *fp, char *arg)
 {
-	int level = atoi(arg);
-
-	debug(LOG_DEBUG, "Entering ndsctl_loglevel [%s]", arg);
+	debug(LOG_DEBUG, "Entering ndsctl_debuglevel [%s]", arg);
 
 	LOCK_CONFIG();
 
-	if (!set_log_level(level)) {
+	if (!set_debuglevel(arg)) {
 		fprintf(fp, "Yes");
-		debug(LOG_NOTICE, "Set debug loglevel to %d.", level);
+		debug(LOG_NOTICE, "Set debug debuglevel to %s.", arg);
 	} else {
 		fprintf(fp, "No");
 	}
 
 	UNLOCK_CONFIG();
 
-	debug(LOG_DEBUG, "Exiting ndsctl_loglevel.");
+	debug(LOG_DEBUG, "Exiting ndsctl_debuglevel.");
 }
 
 static int


### PR DESCRIPTION
Make the debug level  platform independent and less confusing.
Now the levels are 0, 1, 2. We can add more if needed.
The default log level is 1.