### PR TITLE
ndsctl: prevent deadlock with multiple concurrent instances

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -681,6 +681,12 @@ config_read(const char *filename)
 	char line[MAX_BUF], *s, *p1, *p2;
 	int linenum = 0, opcode, value;
 	struct stat sb;
+	char lockfile[] = "/tmp/ndsctl.lock";
+
+	//Remove ndsctl lock file if it exists
+	if (fd = fopen(lockfile, "r")) {
+		remove(lockfile);
+	}
 
 	debug(LOG_INFO, "Reading configuration file '%s'", filename);
 


### PR DESCRIPTION
Prevents deadlock on ndsctl and hangup of NDS if more than two instances of ndsctl are run concurrently.

Multiple instances may be run in the case of FAS with secure level 1. On a busy site probability of this happening is quite high resulting in apparently random failures requiring either a restart of NDS or a reboot.

This solution uses a lock file. The issue may be somewhere in mutex or epoll handling and would probably be better fixed there if that is the case, but this current work around seems reliable.

Now, with this fix, if a multiple concurrent instance of ndsctl finds the lock file present, it exits quietly with an error, logging to syslog.

If a crash was to leave the lock file present, a restart of NDS deletes the file.

A FAS using ndsctl to acquire the client token MUST check the string returned by the call to ndsctl and retry if the string is empty.

Signed-off-by: Rob White <rob@blue-wave.net>