### PR TITLE
ndsctl: clean up FILE pointer

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -685,6 +685,7 @@ config_read(const char *filename)
 
 	//Remove ndsctl lock file if it exists
 	if (fd = fopen(lockfile, "r")) {
+		fclose(fd);
 		remove(lockfile);
 	}
 


### PR DESCRIPTION
fclose before remove
Signed-off-by: Rob White <rob@blue-wave.net>