### PR TITLE
Systemd: Do not set debug level in nodogsplash.service

### DIFF
--- a/debian/nodogsplash.service
+++ b/debian/nodogsplash.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-ExecStart=/usr/bin/nodogsplash -d 5 $OPTIONS
+ExecStart=/usr/bin/nodogsplash $OPTIONS
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Do not set debug level in nodogsplash.service
OS that use systemd eg Debian -
NDS will set the default to "1" or use the value set in nodogsplash.conf

Signed-off-by: Rob White `<rob@blue-wave.net>`