### PR TITLE
Deprecate RedirectURL

### DIFF
--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -214,6 +214,15 @@ FirewallRuleSet users-to-router {
 # After authentication, normally a user is redirected 
 # to their initially requested page. 
 # If RedirectURL is set, the user is redirected to this URL instead.
+
+# NOTE: RedirectURL is deprecated.
+
+#	redirectURL is now redundant as most CPD implementations immediately close the "splash" page
+#	as soon as NDS authenticates, thus redirectURL will not be shown.
+#
+#	This functionality, ie displaying a particular web page as a final "Landing Page",
+#	can be achieved reliably using FAS, with NDS calling the previous "redirectURL" as the FAS page.
+
 # 
 # RedirectURL http://www.ilesansfil.org/
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -859,8 +859,11 @@ config_read(const char *filename)
 		case oStatusPage:
 			config.statuspage = safe_strdup(p1);
 			break;
+
+		// TODO: Deprecate RedirectURL
 		case oRedirectURL:
 			config.redirectURL = safe_strdup(p1);
+			debug(LOG_WARNING, "RedirectURL is now deprecated, please use FAS to provide this functionality");
 			break;
 		case oAuthIdleTimeout:
 			if (sscanf(p1, "%d", &config.auth_idle_timeout) < 1 || config.auth_idle_timeout < 0) {

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -659,7 +659,16 @@ static int preauthenticated(struct MHD_Connection *connection,
 	/* request is directed to us */
 	/* check if client wants to be authenticated */
 	if (check_authdir_match(url, config->authdir)) {
+
 		/* Only the first request will redirected to config->redirectURL.
+		 * TODO: Deprecate redirectURL
+
+			redirectURL is now redundant as most CPD implementations immediately close the "splash" page
+			as soon as NDS authenticates, thus redirectURL will not be shown.
+
+			This functionality, ie displaying a particular web page as a final "Landing Page"
+			can be achieved reliably using FAS, with NDS calling the previous "redirectURL" as the FAS page.
+
 		 * When the client reloads a page when it's authenticated, it should be redirected
 		 * to their origin url
 		 */


### PR DESCRIPTION
redirectURL is now redundant as most CPD implementations immediately close the "splash" page
as soon as NDS authenticates, thus redirectURL will not be shown.
This functionality, ie displaying a particular web page as a final "Landing Page"
can be achieved reliably using FAS, with NDS calling the previous "redirectURL" as the FAS page.

Signed-off-by: Rob White <rob@blue-wave.net>