### PR TITLE
BinAuth: Send redir variable to the binauth script

### DIFF
--- a/docs/source/binauth.rst
+++ b/docs/source/binauth.rst
@@ -1,81 +1,334 @@
 BinAuth Option
 =================
 
-**Key: BinAuth**
+Overview
+********
 
-**Value: /path/to/executable/script**
+**BinAuth provides a method of running a post authentication script** or extension program. BinAuth is ALWAYS local to NDS and as such will have access to all the resources of the local system.
 
-Authenticate a client using an external program that get passed the (optional) username and password value.
-The exit code and output values of the program decide if and how a client is to be authenticated.
+**BinAuth works with, but does not require FAS** and in a simple system can be used to provide site-wide username/password access.
 
-The program will also be called on client authentication and deauthentication.
+**With FAS, the redir variable forwarded to BinAuth** can contain an embedded payload of custom variables defined by the FAS. As FAS is typically remote from the NDS router, this provides a link to the local system.
 
-For the following examples, `binauth` is set to `/etc/nds_auth.sh` in nodogsplash.conf:
+**BinAuth has the means to set a session timeout** interval on a client by client basis.
+
+**BinAuth is called by NDS at the following times:**
+
+ * After the client CPD browser makes an authentication request to NDS
+ * After the client device is granted Internet access by NDS
+ * After the client is deauthenticated by request
+ * After the client idle timeout interval has expired
+ * After the client session timeout interval has expired
+ * After the client is authenticated by ndsctl command
+ * After the client is deauthenticated by ndsctl command
+ * After NDS has received a shutdown command
+
+Example BinAuth Scripts
+***********************
+Two example BinAuth scripts are included in the source files available for download at:
+https://github.com/nodogsplash/nodogsplash/releases
+
+The files can be extracted from the downloaded release archive file and reside in the folder:
+
+`/nodogsplash-[*version*]/forward_authentication_service/binauth`
+
+Example 1 - Sitewide Username/Password
+**************************************
+This example is a script designed to be used with or without FAS and provides site wide Username/Password login for two groups of users, in this case "Staff" and "Guest" with two corresponding sets of credentials. If used without FAS, a special html splash page must be installed, otherwise FAS must forward the required username and password variables.
+
+The "Staff" user is allowed access to the Internet for the full duration of the global sessiontimeout interval before being logged out.
+
+The "Guest" user is allowed access for 10 minutes before being logged out.
+
+Installing Example 1
+********************
+This script has two components, the actual script and an associated html file.
+
+ * binauth_sitewide.sh
+ * splash_sitewide.html
+
+The file binauth_sitewide.sh should be copied to a suitable location on the NDS router, eg `/etc/nodogsplash/`
+
+The file splash_sitewide.html should be copied to `/etc/nodogsplash/htdocs/`
+
+Assuming FAS is not being used, NDS is then configured by setting the BinAuth and SplashPage options in the config file (/etc/config/nodogsplash on Openwrt, or /etc/nodogsplash/nodogsplash.conf on other operating systems.
+
+On OpenWrt this is most easily accomplished by issuing the following commands:
+
+    `uci set nodogsplash.@nodogsplash[0].splashpage='splash_sitewide.html'`
+
+    `uci set nodogsplash.@nodogsplash[0].binauth='/etc/nodogsplash/binauth_sitewide.sh'`
+
+    `uci commit nodogsplash`
+
+The script file must be executable and is flagged as such in the source archive. If necessary set using the command:
+
+    `chmod u+x /etc/nodogsplash/binauth_sitewide.sh`
+
+This script is then activated with the command:
+
+    'service nodogsplash restart'
+
+**The Example 1 script contains the following code:**
 
 .. code-block:: sh
 
-    #!/bin/sh
+ #!/bin/sh
 
-    METHOD="$1"
-    MAC="$2"
+ # EXAMPLE 1
+ # This is an example script for BinAuth
+ # It verifies a client username and password and sets the session length.
+ #
+ # If BinAuth is enabled, NDS will call this script as soon as it has received an authentication request
+ # from the web page served to the client's CPD (Captive Portal Detection) Browser by one of the following:
+ #
+ # 1. splash_sitewide.html
+ # 2. PreAuth
+ # 3. FAS
+ #
+ # The username and password entered by the clent user will be included in the query string sent to NDS via html GET
+ # For an example, see the file splash_sitewide.html
 
-    case "$METHOD" in
-      auth_client)
-        USERNAME="$3"
-        PASSWORD="$4"
-        if [ "$USERNAME" = "Bill" -a "$PASSWORD" = "tms" ]; then
-          # Allow client to access the Internet for one hour (3600 seconds)
-          # Further values are upload and download limits in bytes. 0 for no limit.
-          echo 3600 0 0
-          exit 0
-        else
-          # Deny client to access the Internet.
-          exit 1
-        fi
-        ;;
-      client_auth|client_deauth|idle_deauth|timeout_deauth|ndsctl_auth|ndsctl_deauth|shutdown_deauth)
-        INGOING_BYTES="$3"
-        OUTGOING_BYTES="$4"
-        SESSION_START="$5"
-        SESSION_END="$6"
-        # client_auth: Client authenticated via this script.
-        # client_deauth: Client deauthenticated by the client via splash page.
-        # idle_deauth: Client was deauthenticated because of inactivity.
-        # timeout_deauth: Client was deauthenticated because the session timed out.
-        # ndsctl_auth: Client was authenticated by the ndsctl tool.
-        # ndsctl_deauth: Client was deauthenticated by the ndsctl tool.
-        # shutdown_deauth: Client was deauthenticated by Nodogsplash terminating.
-        ;;
-    esac
+ METHOD="$1"
+ CLIENTMAC="$2"
+
+ case "$METHOD" in
+	auth_client)
+		USERNAME="$3"
+		PASSWORD="$4"
+		if [ "$USERNAME" = "Staff" -a "$PASSWORD" = "weneedit" ]; then
+			# Allow Staff to access the Internet for the global sessiontimeout interval
+			# Further values are reserved for upload and download limits in bytes. 0 for no limit.
+			echo 0 0 0
+			exit 0
+		elif [ "$USERNAME" = "Guest" -a "$PASSWORD" = "thanks" ]; then
+			# Allow Guest to access the Internet for 10 minutes (600 seconds)
+			# Further values are reserved for upload and download limits in bytes. 0 for no limit.
+			echo 600 0 0
+			exit 0
+		else
+			# Deny client access to the Internet.
+			exit 1
+		fi
+
+		;;
+	client_auth|client_deauth|idle_deauth|timeout_deauth|ndsctl_auth|ndsctl_deauth|shutdown_deauth)
+		INGOING_BYTES="$3"
+		OUTGOING_BYTES="$4"
+		SESSION_START="$5"
+		SESSION_END="$6"
+		# client_auth: Client authenticated via this script.
+		# client_deauth: Client deauthenticated by the client via splash page.
+		# idle_deauth: Client was deauthenticated because of inactivity.
+		# timeout_deauth: Client was deauthenticated because the session timed out.
+		# ndsctl_auth: Client was authenticated by the ndsctl tool.
+		# ndsctl_deauth: Client was deauthenticated by the ndsctl tool.
+		# shutdown_deauth: Client was deauthenticated by Nodogsplash terminating.
+		;;
+ esac
+
 
 The `SESSION_START` and `SESSION_END` values are the number of seconds since 1970 or may be 0 for unknown/unlimited.
 
-The splash.html page contains the following code:
+**The splash_sitewide.html page contains the following code:**
 
 .. code-block:: html
 
-    <form method='GET' action='$authaction'>
-    <input type='hidden' name='tok' value='$tok'>
-    <input type='hidden' name='redir' value='$redir'>
-    username: <input type='text' name='username' value='' size='12' maxlength='12'>
-    <br>
-    password: <input type='password' name='password' value='' size='12' maxlength='10'>
-    <br>
-    <input type='submit' value='Enter'>
-    </form>
+ <!DOCTYPE html>
+ <html>
+ <head>
+ <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+ <meta http-equiv="Pragma" content="no-cache">
+ <meta http-equiv="Expires" content="0">
+ <meta charset="utf-8">
+ <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-If a client enters a username 'Bill' and password 'tms', then the configured `binauth` script is executed:
+ <link rel="shortcut icon" href="/images/splash.jpg" type="image/x-icon">
+ <link rel="stylesheet" type="text/css" href="/splash.css">
 
-.. code::
+ <title>$gatewayname Captive Portal.</title>
 
-   /etc/nds_auth.sh auth_client 12:34:56:78:90 'Bill' 'tms'
+ <!--
+ Content:
+	Nodogsplash (NDS), by default, serves this splash page (splash.html)
+	when a client device Captive Portal Detection (CPD) process
+	attempts to send a port 80 request to the Internet.
 
-For the authentication to be successful, the exit code of the script must be 0. The output can be up to three values. First the number of seconds the client is to be authenticated, second and third the maximum number of upload and download bytes limits. Values not given to NDS will resort to default values. Note that the traffic shaping feature that uses the upload/download values does not work right now.
+	You may either embed css in this file or use a separate .css file
+	in the same directory as this file, as demonstrated here.
 
-After initial authentication by the script, Nodogsplash will immediately acknowlege by calling the binauth script again with:
+	It should be noted when designing a custom splash page
+	that for security reasons many CPD implementations:
+		Immediately close the browser when the client has authenticated.
+		Prohibit the use of href links.
+		Prohibit downloading of external files
+			(including .css and .js).
+		Prohibit the execution of javascript.
 
-.. code::
+ Authentication:
+	A client is authenticated on submitting an HTTP form, method=get,
+	passing $authaction, $tok and $redir.
 
-   /etc/nds_auth.sh client_auth 12:34:56:78:90 <incoming_bytes> <outgoing_bytes> <session_start> <session_end>
+	It is also possible to authenticate using an href link to
+	$authtarget but be aware that many device Captive Portal Detection
+	processes prohibit href links, so this method may not work with
+	all client devices.
 
-Nodogsplash will also call the script when the client is authenticated and deauthenticated in general.
+ Available variables:
+	error_msg: $error_msg
+	gatewayname: $gatewayname
+	tok: $tok
+	redir: $redir
+	authaction: $authaction
+	denyaction: $denyaction
+	authtarget: $authtarget
+	clientip: $clientip
+	clientmac: $clientmac
+	clientupload: $clientupload
+	clientdownload: $clientdownload
+	gatewaymac: $gatewaymac
+	nclients: $nclients
+	maxclients: $maxclients
+	uptime: $uptime
+
+ Additional Variables that can be passed back via the HTTP get,
+ or appended to the query string of the authtarget link:
+	username
+	password
+ -->
+
+ </head>
+
+ <body>
+ <div class="offset">
+ <med-blue>$gatewayname Captive Portal.</med-blue>
+ <div class="insert">
+ <img style="height:60px; width:60px; float:left;" src="/images/splash.jpg" alt="Splash Page: For access to the Internet.">
+ <big-red>Welcome!</big-red>
+ <hr>
+ <br>
+ <italic-black>For access to the Internet, please enter your Username and Password.</italic-black>
+ <br><br>
+ <hr>
+
+ <form method="get" action="$authaction">
+ <input type="hidden" name="tok" value="$tok">
+ <input type="hidden" name="redir" value="$redir">
+ <input type="text" placeholder="Enter Username" name="username" value="" size="12" maxlength="12">
+ <br>Username<br><br>
+ <input type="password" placeholder="Enter Password" name="password" value="" size="12" maxlength="10">
+ <br>Password<br><br>
+ <input type="submit" value="Continue">
+ </form>
+
+ <hr>
+ <copy-right>Copyright &copy; The Nodogsplash Contributors 2004-2019.<br>This software is released under the GNU GPL license.</copy-right>
+
+ </div></div>
+ </body>
+ </html>
+
+Example 2 - Local NDS Access Log
+********************************
+
+This example is a script designed to be used with or without FAS and provides local NDS logging. FAS is often remote from the NDS router and this script provides a simple method of interacting directly with the local NDS. FAS can provide the values of custom variables securly embedded as a payload in the redir parameter that is relayed to BinAuth by NDS. FAS can also utilise the username and password parameters to send general purpose variables although these will be readable by the client user on their browser screen.
+
+The log file is stored by default in the /tmp/ directory but no free space checking is done in this simple example.
+It would be a simple matter to change the location of the log file to a USB stick for example.
+
+Installing Example 2
+********************
+This script has a single component, the shell script.
+
+ * binauth_log.sh
+
+The file binauth_log.sh should be copied to a suitable location on the NDS router, eg `/etc/nodogsplash/`
+
+Assuming FAS is not being used, NDS is then configured by setting the BinAuth option in the config file (/etc/config/nodogsplash on Openwrt, or /etc/nodogsplash/nodogsplash.conf on other operating systems.
+
+On OpenWrt this is most easily accomplished by issuing the following commands:
+
+    `uci set nodogsplash.@nodogsplash[0].binauth='/etc/nodogsplash/binauth_log.sh'`
+
+    `uci commit nodogsplash`
+
+The script file must be executable and is flagged as such in the source archive. If necessary set using the command:
+
+    `chmod u+x /etc/nodogsplash/binauth_log.sh`
+
+This script is then activated with the command:
+
+    'service nodogsplash restart'
+
+**The Example 2 script contains the following code:**
+
+.. code-block:: sh
+
+ #!/bin/sh
+
+ # EXAMPLE 2
+ # This is an example script for BinAuth
+ # It can set the session duration per client and writes a local log.
+ #
+ # It also retrieves redir, a variable that either contains the originally requested url
+ # or a url-encoded or aes-encrypted payload of custom variables sent from FAS or PreAuth.
+ #
+ # If BinAuth is enabled, NDS will call this script as soon as it has received an authentication request
+ # from the web page served to the client's CPD (Captive Portal Detection) Browser by one of the following:
+ #
+ # 1. splash.html
+ # 2. PreAuth
+ # 3. FAS
+ #
+
+ # Get the current Date/Time for the log
+ date=$(date)
+
+ #
+ # Get the action method from NDS ie the first command line argument.
+ #
+ # Possible values are:
+ # "auth_client" - NDS requests validation of the client
+ # "client_auth" - NDS has authorised the client
+ # "client_deauth" - NDS has deauthorised the client
+ # "idle_deauth" - NDS has deauthorised the client because the idle timeout duration has been exceeded
+ # "timeout_deauth" - NDS has deauthorised the client because the session length duration has been exceeded
+ # "ndsctl_auth" - NDS has authorised the client because of an ndsctl command
+ # "ndsctl_deauth" - NDS has deauthorised the client because of an ndsctl command
+ # "shutdown_deauth" - NDS has deauthorised the client because it received a shutdown command
+ #
+ action=$1
+
+ if [ $action == "auth_client" ]; then
+	#
+	# The redir parameter is sent to this script as the fifth command line argument in url-encoded form.
+	#
+	# In the case of a simple splash.html login, redir is the URL originally requested by the client CPD.
+	#
+	# In the case of PreAuth or FAS it MAY contain not only the originally requested URL
+	# but also a payload of custom variables defined by Preauth or FAS.
+	#
+	# It may just be simply url-encoded (fas_secure_enabled 0 and 1), or
+	# aes encrypted (fas_secure_enabled 2)
+	#
+	# The username and password variables may be passed from splash.html, FAS or PreAuth and can be used
+	# not just as "username" and "password" but also as general purpose string variables to pass information to BinAuth.
+
+	# Append to the log.
+	echo "$date method=$1 clientmac=$2 username=$3 password=$4 redir=$5" >> /tmp/binauth.log
+ else
+	echo "$date method=$1 clientmac=$2 bytes_incoming=$3 bytes_outgoing=$4 session_start=$5 session_end=$6" >> /tmp/binauth.log
+ fi
+
+
+ # Set length of session in seconds (eg 24 hours is 86400 seconds - if set to 0 then defaults to global sessiontimeout value):
+ session_length=0
+ # The session length could be determined by FAS or PreAuth, on a per client basis, and embedded in the redir variable payload.
+
+ # Finally before exiting, output the session length, followed by two integers (reserved for future use in traffic shaping)
+ echo $session_length 0 0
+
+ # exit 0 tells NDS is is ok to allow the client to have access.
+ # exit 1 would tell NDS to deny access.
+ exit 0
+

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -1,7 +1,7 @@
-Customising nodogsplash
+Customising NoDogSplash
 ########################
 
-After initial installation, Nogogsplash (NDS) should be working in its most basic mode and client Captive Portal Detection (CPD) should pop up the default splash page.
+After initial installation, NoDogSplash (NDS) should be working in its most basic mode and client Captive Portal Detection (CPD) should pop up the default splash page.
 
 Before attempting to customise NDS you should ensure it is working in this basic mode before you start.
 

--- a/docs/source/howitworks.rst
+++ b/docs/source/howitworks.rst
@@ -30,6 +30,57 @@ Summary of Operation
 
  FAS and Binauth can be enabled together. This can give great flexibility with FAS providing authentication and Binauth providing post authentication processing closely linked to  NDS.
 
+
+Captive Portal Detection (CPD)
+******************************
+
+    All modern mobile devices, most desktop operating systems and most browsers now have a CPD process that automatically issues a port 80 request on connection to a network. NDS detects this and serves a special “splash” web page to the connecting client device.
+
+    The port 80 html request made by the client CPD can be one of many vendor specific URLs.
+
+    Typical CPD URLs used are, for example:
+
+    * `http://captive.apple.com/hotspot-detect.html`
+    * `http://connectivitycheck.gstatic.com/generate_204`
+    * `http://connectivitycheck.platform.hicloud.com/generate_204`
+    * `http://www.samsung.com/`
+    * `http://detectportal.firefox.com/success.txt`
+    *  Plus many more
+
+It is important to remember that CPD is designed primarily for mobile devices to automatically detect the presence of a portal and to trigger the login page, without having to resort to breaking SSL/TLS security by requiring the portal to redirect port 443 for example.
+
+Just about all current CPD implementations work very well but some compromises are necessary depending on the application.
+
+The vast majority of devices attaching to a typical Captive Portal are mobile devices. CPD works well giving the initial login page.
+
+For a typical guest wifi, eg a coffee shop, bar, club, hotel etc., a device connects, the Internet is accessed for a while, then the user takes the device out of range.
+
+When taken out of range, a typical mobile device begins periodically polling the wireless spectrum for SSIDs that it knows about to try to obtain a connection again, subject to timeouts to preserve battery life.
+
+Most Captive Portals have a session duration limit (NDS included).
+
+If a previously logged in device returns to within the coverage of the portal, the previously used SSID is recognised and CPD is triggered and tests for an Internet connection in the normal way. Within the session duration limit of the portal, the Internet connection will be established, if the session has expired, the splash page will be displayed again.
+
+Early mobile device implementations of CPD used to poll their detection URL at regular intervals, typically around 30 to 300 seconds. This would trigger the Portal splash page quite quickly if the device stayed in range and the session limit had been reached. 
+
+However it was very quickly realised that this polling kept the WiFi on the device enabled continuously having a very negative effect on battery life, so this polling whilst connected was either increased to a very long interval or removed all together (depending on vendor) to preserve battery charge. As most mobile devices come and go into and out of range, this is not an issue.
+
+A common issue raised is:
+
+*My devices show the splash page when they first connect, but when the authorization expires, they just announce there is no internet connection. I have to make them "forget" the wireless network to see the splash page again. Is this how is it supposed to work?*
+
+The workaround is as described in the issue, or even just manually disconnecting or turning WiFi off and on will simulate a "going out of range", initialising an immediate trigger of the CPD. One or any combination of these workarounds should work, again depending on the particular vendor's implementation of CPD.
+
+In contrast, most laptop/desktop operating systems, and browser versions for these still implement CPD polling whilst online as battery considerations are not so important.
+
+For example, Gnome desktop has its own built in CPD browser with a default interval of 300 seconds. Firefox also defaults to something like 300 seconds. Windows 10 is similar.
+
+This IS how it is supposed to work, but does involve some compromises.
+
+The best solution is to set the session timeout to a value greater than the expected length of time a client device is likely to be present. Experience shows a limit of 24 hours covers most situations eg bars, clubs, coffee shops, motels etc. If for example an hotel has guests regularly staying for a few days, then increase the session timeout as required.
+
+Staff at the venue could have their devices added to the Trusted List if appropriate, but experience shows, it is better not to do this as they very soon learn what to do and can help guests who encounter the issue. (Anything that reduces support calls is good!)
+
 Packet filtering
 ****************
 

--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -123,11 +123,11 @@ header="
 	<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
 	<link rel=\"shortcut icon\" href=\"/images/splash.jpg\" type=\"image/x-icon\">
 	<link rel=\"stylesheet\" type=\"text/css\" href=\"/splash.css\">
-	<title>$gatewayname Hotspot Gateway.</title>
+	<title>$gatewayname Captive Portal.</title>
 	</head>
 	<body>
 	<div class=\"offset\">
-	<med-blue>$gatewayname Hotspot Gateway.</med-blue>
+	<med-blue>$gatewayname Captive Portal.</med-blue>
 	<div class=\"insert\" style=\"max-width:100%;\">
 	<hr>
 "

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -104,11 +104,11 @@ header="
 	<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
 	<link rel=\"shortcut icon\" href=\"/images/splash.jpg\" type=\"image/x-icon\">
 	<link rel=\"stylesheet\" type=\"text/css\" href=\"/splash.css\">
-	<title>$gatewayname Hotspot Gateway.</title>
+	<title>$gatewayname Captive Portal.</title>
 	</head>
 	<body>
 	<div class=\"offset\">
-	<med-blue>$gatewayname Hotspot Gateway.</med-blue>
+	<med-blue>$gatewayname Captive Portal.</med-blue>
 	<div class=\"insert\" style=\"max-width:100%;\">
 	<hr>
 "

--- a/forward_authentication_service/binauth/binauth_log.sh
+++ b/forward_authentication_service/binauth/binauth_log.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# This is an example script for BinAuth
+# It can set the session duration per client and writes a local log.
+#
+# It also retrieves redir, a variable that either contains the originally requested url
+# or a url-encoded or aes-encrypted payload of custom variables sent from FAS or PreAuth.
+#
+# If BinAuth is enabled, NDS will call this script as soon as it has received an authentication request
+# from the web page served to the client's CPD (Captive Portal Detection) Browser by one of the following:
+#
+# 1. splash.html
+# 2. PreAuth
+# 3. FAS
+#
+
+# Get the current Date/Time for the log
+date=$(date)
+
+#
+# Get the action method from NDS ie the first command line argument.
+#
+# Possible values are:
+# "auth_client" - NDS requests validation of the client
+# "client_auth" - NDS has authorised the client
+# "client_deauth" - NDS has deauthorised the client
+# "idle_deauth" - NDS has deauthorised the client because the idle timeout duration has been exceeded
+# "timeout_deauth" - NDS has deauthorised the client because the session length duration has been exceeded
+# "ndsctl_auth" - NDS has authorised the client because of an ndsctl command
+# "ndsctl_deauth" - NDS has deauthorised the client because of an ndsctl command
+# "shutdown_deauth" - NDS has deauthorised the client because it received a shutdown command
+#
+action=$1
+
+if [ $action == "auth_client" ]; then
+	#
+	# The redir parameter is sent to this script as the fifth command line argument in url-encoded form.
+	#
+	# In the case of a simple splash.html login, redir is the URL originally requested by the client CPD.
+	#
+	# In the case of PreAuth or FAS it MAY contain not only the originally requested URL
+	# but also a payload of custom variables defined by Preauth or FAS.
+	#
+	# It may just be simply url-encoded (fas_secure_enabled 0 and 1), or
+	# aes encrypted (fas_secure_enabled 2)
+	#
+	# The username and password variables may be passed from splash.html, FAS or PreAuth and can be used
+	# not just as "username" and "password" but also as general purpose string variables to pass information to BinAuth.
+
+	# Append to the log.
+	echo "$date method=$1 clientmac=$2 username=$3 password=$4 redir=$5" >> /tmp/binauth.log
+else
+	echo "$date method=$1 clientmac=$2 bytes_incoming=$3 bytes_outgoing=$4 session_start=$5 session_end=$6" >> /tmp/binauth.log
+fi
+
+
+# Set length of session in seconds (eg 24 hours is 86400 seconds - if set to 0 then defaults to global sessiontimeout value):
+session_length=0
+# The session length could be determined by FAS or PreAuth, on a per client basis, and embedded in the redir variable payload.
+
+# Finally before exiting, output the session length, followed by two integers (reserved for future use in traffic shaping)
+echo $session_length 0 0
+
+# exit 0 tells NDS is is ok to allow the client to have access.
+# exit 1 would tell NDS to deny access.
+exit 0

--- a/forward_authentication_service/binauth/binauth_sitewide.sh
+++ b/forward_authentication_service/binauth/binauth_sitewide.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# This is an example script for BinAuth
+# It verifies a client username and password and sets the session length.
+#
+# If BinAuth is enabled, NDS will call this script as soon as it has received an authentication request
+# from the web page served to the client's CPD (Captive Portal Detection) Browser by one of the following:
+#
+# 1. splash_sitewide.html
+# 2. PreAuth
+# 3. FAS
+#
+# The username and password entered by the clent user will be included in the query string sent to NDS via html GET
+# For an example, see the file splash_sitewide.html
+
+METHOD="$1"
+CLIENTMAC="$2"
+
+case "$METHOD" in
+	auth_client)
+		USERNAME="$3"
+		PASSWORD="$4"
+		if [ "$USERNAME" = "Staff" -a "$PASSWORD" = "weneedit" ]; then
+			# Allow Staff to access the Internet for the global sessiontimeout interval
+			# Further values are reserved for upload and download limits in bytes. 0 for no limit.
+			echo 0 0 0
+			exit 0
+		elif [ "$USERNAME" = "Guest" -a "$PASSWORD" = "thanks" ]; then
+			# Allow Guest to access the Internet for 10 minutes (600 seconds)
+			# Further values are reserved for upload and download limits in bytes. 0 for no limit.
+			echo 600 0 0
+			exit 0
+		else 
+			# Deny client access to the Internet.
+			exit 1
+		fi
+
+		;;
+	client_auth|client_deauth|idle_deauth|timeout_deauth|ndsctl_auth|ndsctl_deauth|shutdown_deauth)
+		INGOING_BYTES="$3"
+		OUTGOING_BYTES="$4"
+		SESSION_START="$5"
+		SESSION_END="$6"
+		# client_auth: Client authenticated via this script.
+		# client_deauth: Client deauthenticated by the client via splash page.
+		# idle_deauth: Client was deauthenticated because of inactivity.
+		# timeout_deauth: Client was deauthenticated because the session timed out.
+		# ndsctl_auth: Client was authenticated by the ndsctl tool.
+		# ndsctl_deauth: Client was deauthenticated by the ndsctl tool.
+		# shutdown_deauth: Client was deauthenticated by Nodogsplash terminating.
+		;;
+esac
+

--- a/forward_authentication_service/binauth/splash_sitewide.html
+++ b/forward_authentication_service/binauth/splash_sitewide.html
@@ -71,13 +71,17 @@ or appended to the query string of the authtarget link:
 <big-red>Welcome!</big-red>
 <hr>
 <br>
-<italic-black>For access to the Internet, please tap or click Continue.</italic-black>
+<italic-black>For access to the Internet, please enter your Username and Password.</italic-black>
 <br><br>
 <hr>
 
 <form method="get" action="$authaction">
 <input type="hidden" name="tok" value="$tok">
 <input type="hidden" name="redir" value="$redir">
+<input type="text" placeholder="Enter Username" name="username" value="" size="12" maxlength="12">
+<br>Username<br><br>
+<input type="password" placeholder="Enter Password" name="password" value="" size="12" maxlength="10">
+<br>Password<br><br>
 <input type="submit" value="Continue">
 </form>
 	

--- a/resources/splash.css
+++ b/resources/splash.css
@@ -41,7 +41,7 @@
 		margin-right: 5%;
 	}
 
-	input[type=text], input[type=email] {
+	input[type=text], input[type=email], input[type=password] {
 		color: black;
 		background: lightgrey;
 	}

--- a/src/http_microhttpd_utils.c
+++ b/src/http_microhttpd_utils.c
@@ -18,6 +18,7 @@
  */
 
 #include <ctype.h>
+#include "debug.h"
 
 /* blen is the size of buf; slen is the length of src. The input-string need
 ** not be, and the output string will not be, null-terminated. Returns the
@@ -68,10 +69,12 @@ int uh_urlencode(char *buf, int blen, const char *src, int slen)
 			buf[len++] = hex[ src[i] & 15];
 		} else {
 			len = -1;
+			debug(LOG_ERR, "Buffer overflow in uh_urlencode");
 			break;
 		}
 	}
 
+	debug(LOG_INFO, "URL encoded string: %s, length: %d", buf, len);
 	return (i == slen) ? len : -1;
 }
 


### PR DESCRIPTION
This enhancement allows custom variables to be generated by FAS and to be sent to Binauth for action.
This is fully backward compatible with the current release (v4.0.2)
As this is a significant enhancement, the intention is to make a new release v4.1.0

FAS can embed custom variables into redir, allowing local post authentication processing to take place.

Two example scripts are provided for using binauth.

The first provides site-wide username/password login for two user groups, Staff and Guest in the example.
Staff has unlimited access, Guest is limited to 10 minutes per session.

The second provides local logging of NDS, particularly useful with a remote FAS.
The script suggests how a remote FAS can use BinAuth to set session durations on a client by client basis.

The documentation is fully updated.

Signed-off-by: Rob White <rob@blue-wave.net>