### PR TITLE
ndsctl: delete lock file if NDS is not started

### DIFF
--- a/docs/source/binauth.rst
+++ b/docs/source/binauth.rst
@@ -67,7 +67,7 @@ The script file must be executable and is flagged as such in the source archive.
 
 This script is then activated with the command:
 
-    'service nodogsplash restart'
+    `service nodogsplash restart`
 
 **The Example 1 script contains the following code:**
 
@@ -258,7 +258,7 @@ The script file must be executable and is flagged as such in the source archive.
 
 This script is then activated with the command:
 
-    'service nodogsplash restart'
+    `service nodogsplash restart`
 
 **The Example 2 script contains the following code:**
 

--- a/src/ndsctl.c
+++ b/src/ndsctl.c
@@ -114,6 +114,7 @@ static int
 connect_to_server(const char sock_name[])
 {
 	int sock;
+	char lockfile[] = "/tmp/ndsctl.lock";
 	struct sockaddr_un sa_un;
 
 	/* Connect to socket */
@@ -124,6 +125,7 @@ connect_to_server(const char sock_name[])
 
 	if (connect(sock, (struct sockaddr *)&sa_un, strlen(sa_un.sun_path) + sizeof(sa_un.sun_family))) {
 		fprintf(stderr, "ndsctl: nodogsplash probably not started (Error: %s)\n", strerror(errno));
+		remove(lockfile);
 		return -1;
 	}
 


### PR DESCRIPTION
ndsctl: delete lock file if NDS is not started
docs: minor update

Signed-off-by: Rob White <rob@blue-wave.net>