### PR TITLE
PreAuth and BinAuth: Pass user agent string to scripts.

### DIFF
--- a/docs/source/binauth.rst
+++ b/docs/source/binauth.rst
@@ -266,12 +266,13 @@ This script is then activated with the command:
 
  #!/bin/sh
 
- # EXAMPLE 2
  # This is an example script for BinAuth
  # It can set the session duration per client and writes a local log.
  #
- # It also retrieves redir, a variable that either contains the originally requested url
+ # It retrieves redir, a variable that either contains the originally requested url
  # or a url-encoded or aes-encrypted payload of custom variables sent from FAS or PreAuth.
+ #
+ # The client User Agent string is also forwarded to this script.
  #
  # If BinAuth is enabled, NDS will call this script as soon as it has received an authentication request
  # from the web page served to the client's CPD (Captive Portal Detection) Browser by one of the following:
@@ -313,11 +314,22 @@ This script is then activated with the command:
 	#
 	# The username and password variables may be passed from splash.html, FAS or PreAuth and can be used
 	# not just as "username" and "password" but also as general purpose string variables to pass information to BinAuth.
+	#
+	# The client User Agent string is sent as the sixth command line argument.
+	# This can be used to determine much information about the capabilities of the client.
+	# In this case it will be added to the log.
+	#
+	# Both redir and useragent are url-encoded, so decode:
+	redir_enc=$5
+	redir=$(printf "${redir_enc//%/\\x}")
+	useragent_enc=$6
+	useragent=$(printf "${useragent_enc//%/\\x}")
 
 	# Append to the log.
-	echo "$date method=$1 clientmac=$2 username=$3 password=$4 redir=$5" >> /tmp/binauth.log
+
+	echo "$date, method=$1, clientmac=$2, clientip=$7, username=$3, password=$4, redir=$redir, useragent=$useragent" >> /tmp/binauth.log
  else
-	echo "$date method=$1 clientmac=$2 bytes_incoming=$3 bytes_outgoing=$4 session_start=$5 session_end=$6" >> /tmp/binauth.log
+	echo "$date, method=$1, clientmac=$2, bytes_incoming=$3, bytes_outgoing=$4, session_start=$5, session_end=$6" >> /tmp/binauth.log
  fi
 
 
@@ -326,9 +338,10 @@ This script is then activated with the command:
  # The session length could be determined by FAS or PreAuth, on a per client basis, and embedded in the redir variable payload.
 
  # Finally before exiting, output the session length, followed by two integers (reserved for future use in traffic shaping)
+ 
  echo $session_length 0 0
 
  # exit 0 tells NDS is is ok to allow the client to have access.
  # exit 1 would tell NDS to deny access.
+ 
  exit 0
-

--- a/docs/source/preauth.rst
+++ b/docs/source/preauth.rst
@@ -49,11 +49,12 @@ ie:
  1. **fasremoteip**. Not set (defaults to the gateway ip address).
  2. **fas_secure_enable**. Not set (defaults to enabled).
 
+.. note::
+ From version 3.3.1 onwards, the example PreAuth script is preinstalled.
+
+
 Enabling the Preinstalled Login Script (v3.3.1 to 4.0.1)
 ********************************************************
-
-.. note::
- From version 3.3.1 onwards, this example PreAuth script is preinstalled.
 
 On Openwrt, edit (to uncomment) following lines in the /etc/config/nodogsplash file:
 
@@ -70,6 +71,18 @@ To read:
     `option faspath '/nodogsplash_preauth/'`
 
     `option preauth '/usr/lib/nodogsplash/login.sh'`
+
+Enabling the Preinstalled Login Script (v4.0.2 onwards)
+********************************************************
+
+On Openwrt, edit (to uncomment) following line in the /etc/config/nodogsplash file:
+
+    `#option preauth '/usr/lib/nodogsplash/login.sh'`
+
+To read:
+
+    `option preauth '/usr/lib/nodogsplash/login.sh'`
+
 
 For other operating systems edit the equivalent lines in the /etc/nodogsplash/nodogsplash.conf file
 

--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -22,12 +22,16 @@ get_image_file() {
 	fi
 }
 
-# Get the urlencoded querystring
+# Get the urlencoded querystring and user_agent
 query_enc="$1"
+user_agent_enc="$2"
 
 # The query string is sent to us from NDS in a urlencoded form,
 # so we must decode it here so we can parse it:
 query=$(printf "${query_enc//%/\\x}")
+
+# The User Agent string is sent urlencoded also:
+user_agent=$(printf "${user_agent_enc//%/\\x}")
 
 # In this example script we want to ask the client user for
 # their username and email address.
@@ -163,8 +167,8 @@ login_form="
 	<input type=\"hidden\" name=\"clientip\" value=\"$clientip\">
 	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewayname\">
 	<input type=\"hidden\" name=\"redir\" value=\"$requested\">
-	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>:Name<br><br>
-	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>:Email<br><br>
+	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>Name<br><br>
+	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>Email<br><br>
 	<input type=\"submit\" value=\"Continue\" >
 	</form><hr>
 "
@@ -243,7 +247,7 @@ else
 	echo "</form><hr>"
 
 	# In this example we have decided to log all clients who are granted access
-	echo "$(date) Username=$username Email Address=$emailaddr mac address=$clientmac" >> /tmp/ndslog.log
+	echo "$(date), Username=$username, Email Address=$emailaddr, mac address=$clientmac, ip=$clientip, user_agent=$user_agent" >> /tmp/ndslog.log
 fi
 
 # Output the page footer

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -3,12 +3,16 @@
 #Copyright &copy; Blue Wave Projects and Services 2015-2019
 #This software is released under the GNU GPL license.
 
-# Get the urlencoded querystring
+# Get the urlencoded querystring and user_agent
 query_enc="$1"
+user_agent_enc="$2"
 
 # The query string is sent to us from NDS in a urlencoded form,
 # so we must decode it here so we can parse it:
 query=$(printf "${query_enc//%/\\x}")
+
+# The User Agent string is sent urlencoded also:
+user_agent=$(printf "${user_agent_enc//%/\\x}")
 
 # In this example script we want to ask the client user for
 # their username and email address.
@@ -135,8 +139,8 @@ login_form="
 	<input type=\"hidden\" name=\"clientip\" value=\"$clientip\">
 	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewayname\">
 	<input type=\"hidden\" name=\"redir\" value=\"$requested\">
-	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>:Name<br><br>
-	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>:Email<br><br>
+	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>Name<br><br>
+	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>Email<br><br>
 	<input type=\"submit\" value=\"Continue\" >
 	</form><hr>
 "
@@ -215,7 +219,7 @@ else
 	echo "</form><hr>"
 
 	# In this example we have decided to log all clients who are granted access
-	echo "$(date) Username=$username Email Address=$emailaddr mac address=$clientmac" >> /tmp/ndslog.log
+	echo "$(date), Username=$username, Email Address=$emailaddr, mac address=$clientmac, user_agent=$user_agent" >> /tmp/ndslog.log
 fi
 
 # Output the page footer

--- a/forward_authentication_service/binauth/binauth_log.sh
+++ b/forward_authentication_service/binauth/binauth_log.sh
@@ -3,8 +3,10 @@
 # This is an example script for BinAuth
 # It can set the session duration per client and writes a local log.
 #
-# It also retrieves redir, a variable that either contains the originally requested url
+# It retrieves redir, a variable that either contains the originally requested url
 # or a url-encoded or aes-encrypted payload of custom variables sent from FAS or PreAuth.
+#
+# The client User Agent string is also forwarded to this script.
 #
 # If BinAuth is enabled, NDS will call this script as soon as it has received an authentication request
 # from the web page served to the client's CPD (Captive Portal Detection) Browser by one of the following:
@@ -46,11 +48,22 @@ if [ $action == "auth_client" ]; then
 	#
 	# The username and password variables may be passed from splash.html, FAS or PreAuth and can be used
 	# not just as "username" and "password" but also as general purpose string variables to pass information to BinAuth.
+	#
+	# The client User Agent string is sent as the sixth command line argument.
+	# This can be used to determine much information about the capabilities of the client.
+	# In this case it will be added to the log.
+	#
+	# Both redir and useragent are url-encoded, so decode:
+	redir_enc=$5
+	redir=$(printf "${redir_enc//%/\\x}")
+	useragent_enc=$6
+	useragent=$(printf "${useragent_enc//%/\\x}")
 
 	# Append to the log.
-	echo "$date method=$1 clientmac=$2 username=$3 password=$4 redir=$5" >> /tmp/binauth.log
+
+	echo "$date, method=$1, clientmac=$2, clientip=$7, username=$3, password=$4, redir=$redir, useragent=$useragent" >> /tmp/binauth.log
 else
-	echo "$date method=$1 clientmac=$2 bytes_incoming=$3 bytes_outgoing=$4 session_start=$5 session_end=$6" >> /tmp/binauth.log
+	echo "$date, method=$1, clientmac=$2, bytes_incoming=$3, bytes_outgoing=$4, session_start=$5, session_end=$6" >> /tmp/binauth.log
 fi
 
 

--- a/forward_authentication_service/binauth/binauth_sitewide.sh
+++ b/forward_authentication_service/binauth/binauth_sitewide.sh
@@ -20,6 +20,10 @@ case "$METHOD" in
 	auth_client)
 		USERNAME="$3"
 		PASSWORD="$4"
+		REDIR="$5"
+		USER_AGENT="$6"
+		CLIENTIP="$7"
+
 		if [ "$USERNAME" = "Staff" -a "$PASSWORD" = "weneedit" ]; then
 			# Allow Staff to access the Internet for the global sessiontimeout interval
 			# Further values are reserved for upload and download limits in bytes. 0 for no limit.


### PR DESCRIPTION
  * BinAuth - Send User Agent string and client-ip to the binauth script [bluewavenet]
  * BinAuth - Update the two example BinAuth scripts showing use of passed arguments [bluewavenet]
  * Documentation - Update BinAuth section [bluewavenet]
  * PreAuth - Send User Agent string to the preauth script [bluewavenet]
  * PreAuth - Update the example PreAuth script showing use of passed arguments [bluewavenet]
  * Documentation - Update PreAuth section [bluewavenet]

Bump to version 4.2.0 as this adds significant functionality with backwards compatibility.


Signed-off-by: Rob White `<rob@blue-wave.net>`