### PR TITLE
fix: NDS uptime if NTP client enabled

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -226,14 +226,18 @@ main_loop(void)
 	char *fasssl = NULL;
 	char *phpcmd = NULL;
 	char *preauth_dir = NULL;
+	time_t sysuptime;
 
 	config = config_get_config();
+
+	sysuptime = get_system_uptime ();
+	debug(LOG_INFO, "main: System Uptime is %li seconds", sysuptime);
 
 	/* Set the time when nodogsplash started */
 	if (!started_time) {
 		debug(LOG_INFO, "Setting started_time");
 		started_time = time(NULL);
-	} else if (started_time < MINIMUM_STARTED_TIME) {
+	} else if (started_time < (time(NULL) - sysuptime)) {
 		debug(LOG_WARNING, "Detected possible clock skew - re-setting started_time");
 		started_time = time(NULL);
 	}

--- a/src/util.h
+++ b/src/util.h
@@ -62,6 +62,9 @@ char *format_time(time_t time, char buf[64]);
 /* @brief Check if the address is a valid IPv4 or IPv6 address */
 int is_addr(const char* addr);
 
+/* @brief Returns System Uptime in seconds */
+time_t get_system_uptime();
+
 /*
  * @brief Mallocs and returns nodogsplash uptime string
  */


### PR DESCRIPTION
NDS uptime may be from seconds to years (!!) too large if NTP client is
enabled when the system starts and there is no hardware RTC.

NDS started_time is deliberately left untouched, uptime discrepancy is
logged when debuglevel is >1 but uptime is correctly calculated.

Signed-off-by: Rob White <rob@blue-wave.net>