### PR TITLE
FAS: Introduce hash_id mode.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -215,6 +215,7 @@ config_init(void)
 	config.fas_remotefqdn = NULL;
 	config.fas_url = NULL;
 	config.fas_ssl = NULL;
+	config.fas_hid = NULL;
 	config.fas_path = DEFAULT_FASPATH;
 	config.webroot = safe_strdup(DEFAULT_WEBROOT);
 	config.splashpage = safe_strdup(DEFAULT_SPLASHPAGE);

--- a/src/conf.h
+++ b/src/conf.h
@@ -160,6 +160,7 @@ typedef struct {
 	char *fas_remotefqdn;		/**< @brief FQDN of a remote FAS */
 	char *fas_url;			/**< @brief URL of a remote FAS */
 	char *fas_ssl;			/**< @brief SSL provider for FAS */
+	char *fas_hid;			/**< @brief Hash provider for FAS */
 	char *webroot;			/**< @brief Directory containing splash pages, etc. */
 	char *splashpage;		/**< @brief Name of main splash page */
 	char *statuspage;		/**< @brief Name of info status page */

--- a/src/util.c
+++ b/src/util.c
@@ -81,6 +81,27 @@ extern int created_httpd_threads;
 extern int current_httpd_threads;
 
 
+int hash_str(char* hash, int hash_len, const char *src)
+{
+	char *hashcmd = NULL;
+
+	s_config *config = config_get_config();
+
+	safe_asprintf(&hashcmd, "printf '%s' | %s | awk -F' ' '{printf $1}'", src, config->fas_hid);
+
+	if (execute_ret_url_encoded(hash, hash_len - 1, hashcmd) == 0) {
+		debug(LOG_DEBUG, "Source string: %s", src);
+		debug(LOG_DEBUG, "Hashed string: %s", hash);
+	} else {
+		debug(LOG_ERR, "Failed to hash string");
+		free (hashcmd);
+		return -1;
+	}
+	free (hashcmd);
+	return 0;
+}
+
+
 static int _execute_ret(char* msg, int msg_len, const char *cmd)
 {
 	struct sigaction sa, oldsa;

--- a/src/util.h
+++ b/src/util.h
@@ -65,14 +65,19 @@ int is_addr(const char* addr);
 /* @brief Returns System Uptime in seconds */
 time_t get_system_uptime();
 
+/* @brief Returns the hash of a string */
+int hash_str(char *buf, int hash_len, const char *src);
+
 /*
  * @brief Mallocs and returns nodogsplash uptime string
  */
 char *get_uptime_string(char buf[64]);
+
 /*
  * @brief Writes a human-readable paragraph of the status of the nodogsplash process
  */
 void ndsctl_status(FILE *fp);
+
 /*
  * @brief Writes a machine-readable dump of currently connected clients
  */


### PR DESCRIPTION
Enhances security and mitigates issues accessing ndsctl remotely to obtain the client token.

In addition, no additional packages are required allowing legacy low flash/ram devices to be used.

 * For option fas_secure_enabled '1', NDS adds the hash of the client token (hid) to the query string.

 * FAS concatenates hid and the fas key and hashes the result.

 * This new hash is added to the query string returned to NDS instead of the client token.

 * NDS then compares this hash with one it calculates itself from the client token and the pre-shared key.


For option fas_secure_enabled '2', the FAS can return either the client token in clear text
or can return the concatenated hash as for fas_secure_enabled '1', NDS will detect which is used.

Signed-off-by: Rob White `<rob@blue-wave.net>`