### PR TITLE
Fix typo in project name at Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ how to customize its behaviour for your application.
 
 ## 1. Overview
 
-**Nodogspash** (NDS) is a high performance, small footprint Captive Portal, offering by default a simple splash page restricted Internet connection, yet incorporates an API that allows the creation of sophisticated authentication applications.
+**Nodogsplash** (NDS) is a high performance, small footprint Captive Portal, offering by default a simple splash page restricted Internet connection, yet incorporates an API that allows the creation of sophisticated authentication applications.
 
 **Captive Portal Detection (CPD)**
 


### PR DESCRIPTION
Fix typo in project name in Readme#1-overview section