### PR TITLE
Fix: restart at high loads, Fix: deadlock

### DIFF
--- a/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh
+++ b/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh
@@ -3,6 +3,8 @@
 # Check if nodogsplash is running
 if ndsctl status &> /dev/null; then
   if [ "$(uci -q get nodogsplash.@nodogsplash[0].fwhook_enabled)" = "1" ]; then
+    ndspid=$(ps | grep nodogsplash | awk -F ' ' 'NR==2 {print $1}')
+    echo "fwhook restart request received - restarting " | logger -p "daemon.err" -s -t "nodogsplash[$ndspid]: "
     /etc/init.d/nodogsplash restart
   fi
 fi

--- a/src/auth.h
+++ b/src/auth.h
@@ -28,6 +28,7 @@
 
 int auth_client_deauth(unsigned id, const char *reason);
 int auth_client_auth(unsigned id, const char *reason);
+int auth_client_auth_nolock(const unsigned id, const char *reason);
 int auth_client_trust(const char *mac);
 int auth_client_untrust(const char *mac);
 int auth_client_allow(const char *mac);

--- a/src/common.h
+++ b/src/common.h
@@ -30,7 +30,7 @@
 #define MAX_BUF 4096
 
 /* Max length of a query string in bytes */
-#define QUERYMAXLEN 2048
+#define QUERYMAXLEN 4096
 
 /* Separator for Preauth query string */
 #define QUERYSEPARATOR ", "

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -1002,6 +1002,8 @@ iptables_fw_counters_update(void)
 	config = config_get_config();
 	af = config->ip6 ? AF_INET6 : AF_INET;
 
+	LOCK_CLIENT_LIST();
+
 	/* Look for outgoing traffic of authenticated clients. */
 	safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_OUTGOING);
 	output = popen(script, "r");
@@ -1026,7 +1028,6 @@ iptables_fw_counters_update(void)
 				continue;
 			}
 			debug(LOG_DEBUG, "Read outgoing traffic for %s: Bytes=%llu", ip, counter);
-			LOCK_CLIENT_LIST();
 			if ((p1 = client_list_find_by_ip(ip))) {
 				if (p1->counters.outgoing < counter) {
 					p1->counters.outgoing = counter;
@@ -1036,7 +1037,6 @@ iptables_fw_counters_update(void)
 			} else {
 				debug(LOG_WARNING, "Could not find %s in client list", ip);
 			}
-			UNLOCK_CLIENT_LIST();
 		}
 	}
 	pclose(output);
@@ -1065,7 +1065,6 @@ iptables_fw_counters_update(void)
 				continue;
 			}
 			debug(LOG_DEBUG, "Read incoming traffic for %s: Bytes=%llu", ip, counter);
-			LOCK_CLIENT_LIST();
 			if ((p1 = client_list_find_by_ip(ip))) {
 				if (p1->counters.incoming < counter) {
 					p1->counters.incoming = counter;
@@ -1074,10 +1073,10 @@ iptables_fw_counters_update(void)
 			} else {
 				debug(LOG_WARNING, "Could not find %s in client list", ip);
 			}
-			UNLOCK_CLIENT_LIST();
 		}
 	}
 	pclose(output);
+	UNLOCK_CLIENT_LIST();
 
 	return 0;
 }

--- a/src/ndsctl_thread.c
+++ b/src/ndsctl_thread.c
@@ -304,14 +304,15 @@ ndsctl_auth(FILE *fp, char *arg)
 	LOCK_CLIENT_LIST();
 	client = client_list_find_by_any(arg, arg, arg);
 	id = client ? client->id : 0;
-	UNLOCK_CLIENT_LIST();
 
 	if (id) {
-		rc = auth_client_auth(id, "ndsctl_auth");
+		rc = auth_client_auth_nolock(id, "ndsctl_auth");
 	} else {
 		debug(LOG_DEBUG, "Client not found.");
 		rc = -1;
 	}
+	UNLOCK_CLIENT_LIST();
+
 
 	if (rc == 0) {
 		fprintf(fp, "Yes");


### PR DESCRIPTION
Fix a dead lock and a client list lock. [lynxis]

Fix: Memory corruption at high loads. [bluewavenet]
 *  Symptom was spontaneous restart of NDS often with no errors.
 *  Caused by coding error introduced by previous changes.
 *  Added improved checking and debuglevel logging when calling MHD.
 *  Added debuglevel logging for case of firewall restart.
 *  Return error 403(forbidden) rather than 503(internal server error) when client attempts to use a forbidden http method.
 *  Return error 403(forbidden) rather than 503(internal server error) when client attempts to use an invalid ip or mac address.
 *  Revert QUERYMAXLEN to 4096 bytes to prevent query string truncation when a client session deauthenticates whilst client is using some types of vpn software.
    
    Signed-off-by: Rob White `<rob@blue-wave.net>`
