### PR TITLE
fas: get the client interface connections.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ install:
 	cp resources/splash.jpg $(DESTDIR)/etc/nodogsplash/htdocs/images/
 	mkdir -p $(DESTDIR)/usr/lib/nodogsplash
 	cp forward_authentication_service/PreAuth/demo-preauth.sh $(DESTDIR)/usr/lib/nodogsplash/login.sh
+	cp forward_authentication_service/libs/get_client_interface.sh $(DESTDIR)/usr/lib/nodogsplash/
 	cp forward_authentication_service/fas-aes/fas-aes.php $(DESTDIR)/etc/nodogsplash/
 
 checkastyle:

--- a/openwrt/nodogsplash/Makefile
+++ b/openwrt/nodogsplash/Makefile
@@ -60,6 +60,7 @@ define Package/nodogsplash/install
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/uci-defaults/40_nodogsplash $(1)/etc/uci-defaults/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/nodogsplash/login.sh
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/nodogsplash/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/nodogsplash/
 endef
 

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -881,6 +881,7 @@ static int redirect_to_splashpage(struct MHD_Connection *connection, t_client *c
 static char *construct_querystring(t_client *client, char *originurl, char *querystr ) {
 
 	char hash[128] = {0};
+	char clientif[64] = {0};
 
 	s_config *config = config_get_config();
 
@@ -899,15 +900,17 @@ static char *construct_querystring(t_client *client, char *originurl, char *quer
 			}
 
 	} else if (config->fas_secure_enabled == 2) {
+		get_client_interface(clientif, sizeof(clientif), client->mac);
 		snprintf(querystr, QUERYMAXLEN,
-			"clientip=%s%sclientmac=%s%sgatewayname=%s%stok=%s%sgatewayaddress=%s%sauthdir=%s%soriginurl=%s",
+			"clientip=%s%sclientmac=%s%sgatewayname=%s%stok=%s%sgatewayaddress=%s%sauthdir=%s%soriginurl=%s%sclientif=%s",
 			client->ip, QUERYSEPARATOR,
 			client->mac, QUERYSEPARATOR,
 			config->gw_name, QUERYSEPARATOR,
 			client->token, QUERYSEPARATOR,
 			config->gw_address, QUERYSEPARATOR,
 			config->authdir, QUERYSEPARATOR,
-			originurl);
+			originurl, QUERYSEPARATOR,
+			clientif);
 
 	} else {
 		snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s", client->ip, config->gw_name);

--- a/src/util.c
+++ b/src/util.c
@@ -80,6 +80,24 @@ extern unsigned int authenticated_since_start;
 extern int created_httpd_threads;
 extern int current_httpd_threads;
 
+int get_client_interface(char* clientif, int clientif_len, const char *climac)
+{
+	char *clifcmd = NULL;
+
+	safe_asprintf(&clifcmd, "/usr/lib/nodogsplash/./get_client_interface.sh %s", climac);
+
+	if (execute_ret_url_encoded(clientif, clientif_len - 1, clifcmd) == 0) {
+		debug(LOG_DEBUG, "Client Mac Address: %s", climac);
+		debug(LOG_DEBUG, "Client Connection(s) [localif] [remotemeshnodemac] [localmeshif]: %s", clientif);
+	} else {
+		debug(LOG_ERR, "Failed to get client connections - client probably offline");
+		free (clifcmd);
+		return -1;
+	}
+	free (clifcmd);
+	return 0;
+}
+
 
 int hash_str(char* hash, int hash_len, const char *src)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -68,6 +68,12 @@ time_t get_system_uptime();
 /* @brief Returns the hash of a string */
 int hash_str(char *buf, int hash_len, const char *src);
 
+/* @brief Returns the client local interface,
+ * meshnode mac address (null if mesh not present) and
+ * local mesh interface (null if mesh not present)
+ */
+int get_client_interface(char* clientif, int clientif_len, const char *climac);
+
 /*
  * @brief Mallocs and returns nodogsplash uptime string
  */


### PR DESCRIPTION
When option fas_secure_enabled '2' is set, get the client interface connections.

The client interface connections string is of the form:
[localif] [remotemeshnodemac] [localmeshif]

This is added to the query string as "clientif".

[remotemeshnodemac] and [localmeshif] will be null if  the client is connected
to a local interface or 802.11s mesh networking is not active.

This can be used to change the response of the FAS captive portal login page,
depending on the interface the client is connected to.

Connections to local wireless interfaces and
remote 802.11s mesh node connections are detected.

Signed-off-by: Rob White <rob@blue-wave.net>