### PR TITLE
Implement unescape callback for MHD (libmicrohttpd)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ install:
 	mkdir -p $(DESTDIR)/usr/lib/nodogsplash
 	cp forward_authentication_service/PreAuth/demo-preauth.sh $(DESTDIR)/usr/lib/nodogsplash/login.sh
 	cp forward_authentication_service/libs/get_client_interface.sh $(DESTDIR)/usr/lib/nodogsplash/
+	cp forward_authentication_service/libs/unescape.sh $(DESTDIR)/usr/lib/nodogsplash/
 	cp forward_authentication_service/fas-aes/fas-aes.php $(DESTDIR)/etc/nodogsplash/
 
 checkastyle:

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-#Copyright (C) The Nodogsplash Contributors 2004-2019
-#Copyright (C) Blue Wave Projects and Services 2015-2019
+#Copyright (C) The Nodogsplash Contributors 2004-2020
+#Copyright (C) Blue Wave Projects and Services 2015-2020
 #This software is released under the GNU GPL license.
 
 # functions:

--- a/forward_authentication_service/libs/unescape.sh
+++ b/forward_authentication_service/libs/unescape.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#Copyright (C) The Nodogsplash Contributors 2004-2020
+#Copyright (C) Blue Wave Projects and Services 2015-2020
+#This software is released under the GNU GPL license.
+
+option="$1"
+inputstr="$2"
+
+if [ "$option" == "-url" ]; then
+	printf "${inputstr//%/\\x}"
+else
+	echo "Invalid option"
+	exit 1
+fi

--- a/openwrt/nodogsplash/Makefile
+++ b/openwrt/nodogsplash/Makefile
@@ -61,6 +61,7 @@ define Package/nodogsplash/install
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/nodogsplash/login.sh
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/nodogsplash/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/nodogsplash/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/nodogsplash/
 endef
 

--- a/openwrt/nodogsplash/files/etc/config/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/config/nodogsplash
@@ -31,7 +31,7 @@ config nodogsplash
 	# Both modes may be customised or a full custom system can be developed using FAS and BinAuth
 	# See documentation at: https://nodogsplashdocs.readthedocs.io/
 	#
-	#option login_option_enabled '1'
+	option login_option_enabled '0'
 
 	# WebRoot
 	# Default: /etc/nodogsplash/htdocs

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -33,7 +33,7 @@ GatewayInterface br-lan
 # Both modes may be customised or a full custom system can be developed using FAS and BinAuth
 # See documentation at: https://nodogsplashdocs.readthedocs.io/
 #
-#login_option_enabled 1
+login_option_enabled 0
 
 
 # Option: WebRoot

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -1456,3 +1456,20 @@ static int serve_file(struct MHD_Connection *connection, t_client *client, const
 
 	return ret;
 }
+
+size_t unescape(void * cls, struct MHD_Connection *c, char *src)
+{
+	char unescapecmd[QUERYMAXLEN] = {0};
+	char msg[QUERYMAXLEN] = {0};
+
+	debug(LOG_INFO, "Escaped string=%s\n", src);
+	snprintf(unescapecmd, QUERYMAXLEN, "/usr/lib/nodogsplash/./unescape.sh -url \"%s\"", src);
+	debug(LOG_DEBUG, "unescapecmd=%s\n", unescapecmd);
+
+	if (execute_ret_url_encoded(msg, sizeof(msg) - 1, unescapecmd) == 0) {
+		debug(LOG_INFO, "Unescaped string=%s\n", msg);
+		strcpy(src, msg);
+	}
+
+	return strlen(src);
+}

--- a/src/http_microhttpd.h
+++ b/src/http_microhttpd.h
@@ -2,6 +2,7 @@
 #define NDS_MICROHTTPD_H
 
 #include <stdio.h>
+#include <string.h>
 
 struct MHD_Connection;
 
@@ -16,5 +17,7 @@ int libmicrohttpd_cb (void *cls,
 					const char *version,
 					const char *upload_data, size_t *upload_data_size, void **ptr);
 
+
+size_t unescape(void * cls, struct MHD_Connection *c, char *src);
 
 #endif // NDS_MICROHTTPD_H

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,7 @@
 
 #include "common.h"
 #include "http_microhttpd.h"
+#include "http_microhttpd_utils.h"
 #include "safe.h"
 #include "debug.h"
 #include "conf.h"
@@ -266,14 +267,14 @@ main_loop(void)
 	debug(LOG_NOTICE, "Detected gateway %s at %s (%s)", config->gw_interface, config->gw_ip, config->gw_mac);
 
 	/* Initializes the web server */
-	if ((webserver = MHD_start_daemon(
-						MHD_USE_EPOLL_INTERNALLY | MHD_USE_TCP_FASTOPEN,
-						config->gw_port,
-						NULL, NULL,
-						libmicrohttpd_cb, NULL,
-						MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int) 120,
-						MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
-						MHD_OPTION_END)) == NULL) {
+	if ((webserver = MHD_start_daemon(MHD_USE_EPOLL_INTERNALLY | MHD_USE_TCP_FASTOPEN,
+							config->gw_port,
+							NULL, NULL,
+							libmicrohttpd_cb, NULL,
+							MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int) 120,
+							MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
+							MHD_OPTION_UNESCAPE_CALLBACK, unescape,
+							MHD_OPTION_END)) == NULL) {
 		debug(LOG_ERR, "Could not create web server: %s", strerror(errno));
 		exit(1);
 	}


### PR DESCRIPTION
This is a fix to allow "+" and "&" characters in user data passed to MHD in get requests.
Reported in issue #476, this effected PreAuth and Binauth.
"+" and "&" characters can now be used in form data, eg passwords etc.

Signed-off-by: Rob White <rob@blue-wave.net>