### PR TITLE
4.4.1beta Enhancements and bug fixes

### DIFF
--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -25,6 +25,38 @@
 #
 #############################################################################################
 
+
+
+# Customise the Logfile location:
+#
+# mountpoint is the mount point for the storage the log is to be kept on
+#
+# /tmp on OpenWrt is tmpfs (ram disk) and does not survive a reboot.
+#
+# /run on Raspbian is also tmpfs and also does not survive a reboot.
+#
+# These choices for OpenWrt and Raspbian are a good default for testing purposes
+# as long term use on internal flash could cause memory wear
+# In a production system, use the mount point of a usb drive for example
+#
+#
+# logdir is the directory path for the log file
+#
+#
+# logname is the name of the log file
+#
+
+#For Openwrt:
+mountpoint="/tmp"
+logdir="/tmp/ndslog/"
+logname="ndslog.log"
+
+#For Raspbian:
+#mountpoint="/run"
+#logdir="/run/ndslog/"
+#logname="ndslog.log"
+
+
 # functions:
 
 get_image_file() {
@@ -82,7 +114,13 @@ get_client_zone () {
 }
 
 write_log () {
-	logfile="/tmp/ndslog.log"
+
+	if [ ! -d "$logdir" ]; then
+		mkdir -p "$logdir"
+	fi
+
+	logfile="$logdir""$logname"
+	awkcmd="awk ""'\$6==""\"$mountpoint\"""{print \$4}'"
 	min_freespace_to_log_ratio=10
 	datetime=$(date)
 
@@ -92,7 +130,7 @@ write_log () {
 
 	ndspid=$(ps | grep nodogsplash | awk -F ' ' 'NR==2 {print $1}')
 	filesize=$(ls -s -1 $logfile | awk -F' ' '{print $1}')
-	available=$(df |grep /tmp | awk -F ' ' '$6=="/tmp"{print $4}')
+	available=$(df | grep "$mountpoint" | eval "$awkcmd")
 	sizeratio=$(($available/$filesize))
 
 	if [ $sizeratio -ge $min_freespace_to_log_ratio ]; then

--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 #Copyright (C) The Nodogsplash Contributors 2004-2020
-#Copyright (C) Blue Wave Projects and Services 2015-2020
+#Copyright (C) BlueWave Projects and Services 2015-2020
 #This software is released under the GNU GPL license.
+#
+# Warning - shebang sh is for compatibliity with busybox ash (eg on OpenWrt)
+# This is changed to bash automatically by Makefile for Debian
+#
 
 #############################################################################################
 #

--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -184,8 +184,10 @@ for var in $queryvarlist; do
 	eval $var=$(echo "$query_enc" | awk -F "$var%3d" '{print $2}' | awk -F "%2c%20$nextvar%3d" '{print $1}')
 done
 
-# URL decode vars that need it:
+# URL decode and htmlentity encode vars that need it:
 gatewayname=$(printf "${gatewayname//%/\\x}")
+htmlentityencode "$gatewayname"
+gatewaynamehtml=$entityencoded
 username=$(printf "${username//%/\\x}")
 htmlentityencode "$username"
 username=$entityencoded
@@ -226,11 +228,11 @@ header="<!DOCTYPE html>
 	<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
 	<link rel=\"shortcut icon\" href=\"/images/splash.jpg\" type=\"image/x-icon\">
 	<link rel=\"stylesheet\" type=\"text/css\" href=\"/splash.css\">
-	<title>$gatewayname.</title>
+	<title>$gatewaynamehtml.</title>
 	</head>
 	<body>
 	<div class=\"offset\">
-	<med-blue>$gatewayname.</med-blue>
+	<med-blue>$gatewaynamehtml.</med-blue>
 	<div class=\"insert\" style=\"max-width:100%;\">
 	<hr>
 "

--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -283,7 +283,7 @@ echo -e "$header"
 
 # Check if the client is already logged in and has tapped "back" on their browser
 # Make this a friendly message explaining they are good to go
-if [ "$status" == "authenticated" ]; then
+if [ "$status" = "authenticated" ]; then
 	echo "<p><big-red>You are already logged in and have access to the Internet.</big-red></p>"
 	echo "<hr>"
 	echo "<p><italic-black>You can use your Browser, Email and other network Apps as you normally would.</italic-black></p>"

--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -163,11 +163,16 @@ user_agent=$(printf "${user_agent_enc//%/\\x}")
 
 # Parse for the variables returned by NDS:
 hid_present=$(echo "$query_enc" | grep "hid")
+status_present=$(echo "$query_enc" | grep "status")
 
-if [ -z "$hid_present" ]; then
-	queryvarlist="clientip gatewayname redir status username emailaddr"
+if [ ! -z "$status_present" ]; then
+	queryvarlist="clientip gatewayname gatewayaddress status"
+elif [ -z "$hid_present" ]; then
+	hid="0"
+	gatewayaddress="0"
+	queryvarlist="clientip gatewayname redir username emailaddr"
 else
-	queryvarlist="clientip gatewayname hid redir status username emailaddr"
+	queryvarlist="clientip gatewayname hid gatewayaddress redir username emailaddr"
 fi
 
 for var in $queryvarlist; do
@@ -176,7 +181,6 @@ for var in $queryvarlist; do
 done
 
 # URL decode vars that need it:
-
 gatewayname=$(printf "${gatewayname//%/\\x}")
 username=$(printf "${username//%/\\x}")
 htmlentityencode "$username"
@@ -208,8 +212,7 @@ get_client_zone
 
 
 
-header="
-	<!DOCTYPE html>
+header="<!DOCTYPE html>
 	<html>
 	<head>
 	<meta http-equiv=\"Cache-Control\" content=\"no-cache, no-store, must-revalidate\">
@@ -261,6 +264,7 @@ login_form="
 	<input type=\"hidden\" name=\"clientip\" value=\"$clientip\">
 	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewayname\">
 	<input type=\"hidden\" name=\"hid\" value=\"$hid\">
+	<input type=\"hidden\" name=\"gatewayaddress\" value=\"$gatewayaddress\">
 	<input type=\"hidden\" name=\"redir\" value=\"$requested\">
 	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>Name<br><br>
 	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>Email<br><br>

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -237,7 +237,7 @@ echo -e "$header"
 
 # Check if the client is already logged in and has tapped "back" on their browser
 # Make this a friendly message explaining they are good to go
-if [ "$status" == "authenticated" ]; then
+if [ "$status" = "authenticated" ]; then
 	echo "<p><big-red>You are already logged in and have access to the Internet.</big-red></p>"
 	echo "<hr>"
 	echo "<p><italic-black>You can use your Browser, Email and other network Apps as you normally would.</italic-black></p>"

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -2,6 +2,10 @@
 #Copyright (C) The Nodogsplash Contributors 2004-2020
 #Copyright (C) BlueWave Projects and Services 2015-2020
 #This software is released under the GNU GPL license.
+#
+# Warning - shebang sh is for compatibliity with busybox ash (eg on OpenWrt)
+# This is changed to bash automatically by Makefile for Debian
+#
 
 # functions:
 

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -149,8 +149,10 @@ for var in $queryvarlist; do
 	eval $var=$(echo "$query_enc" | awk -F "$var%3d" '{print $2}' | awk -F "%2c%20$nextvar%3d" '{print $1}')
 done
 
-# URL decode vars that need it:
+# URL decode and htmlentity encode vars that need it:
 gatewayname=$(printf "${gatewayname//%/\\x}")
+htmlentityencode "$gatewayname"
+gatewaynamehtml=$entityencoded
 username=$(printf "${username//%/\\x}")
 htmlentityencode "$username"
 username=$entityencoded
@@ -191,11 +193,11 @@ header="<!DOCTYPE html>
 	<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
 	<link rel=\"shortcut icon\" href=\"/images/splash.jpg\" type=\"image/x-icon\">
 	<link rel=\"stylesheet\" type=\"text/css\" href=\"/splash.css\">
-	<title>$gatewayname.</title>
+	<title>$gatewaynamehtml.</title>
 	</head>
 	<body>
 	<div class=\"offset\">
-	<med-blue>$gatewayname.</med-blue>
+	<med-blue>$gatewaynamehtml.</med-blue>
 	<div class=\"insert\" style=\"max-width:100%;\">
 	<hr>
 "

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -128,11 +128,16 @@ user_agent=$(printf "${user_agent_enc//%/\\x}")
 
 # Parse for the variables returned by NDS:
 hid_present=$(echo "$query_enc" | grep "hid")
+status_present=$(echo "$query_enc" | grep "status")
 
-if [ -z "$hid_present" ]; then
-	queryvarlist="clientip gatewayname redir status username emailaddr"
+if [ ! -z "$status_present" ]; then
+	queryvarlist="clientip gatewayname gatewayaddress status"
+elif [ -z "$hid_present" ]; then
+	hid="0"
+	gatewayaddress="0"
+	queryvarlist="clientip gatewayname redir username emailaddr"
 else
-	queryvarlist="clientip gatewayname hid redir status username emailaddr"
+	queryvarlist="clientip gatewayname hid gatewayaddress redir username emailaddr"
 fi
 
 for var in $queryvarlist; do
@@ -141,7 +146,6 @@ for var in $queryvarlist; do
 done
 
 # URL decode vars that need it:
-
 gatewayname=$(printf "${gatewayname//%/\\x}")
 username=$(printf "${username//%/\\x}")
 htmlentityencode "$username"
@@ -173,8 +177,7 @@ get_client_zone
 
 
 
-header="
-	<!DOCTYPE html>
+header="<!DOCTYPE html>
 	<html>
 	<head>
 	<meta http-equiv=\"Cache-Control\" content=\"no-cache, no-store, must-revalidate\">
@@ -215,6 +218,7 @@ login_form="
 	<input type=\"hidden\" name=\"clientip\" value=\"$clientip\">
 	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewayname\">
 	<input type=\"hidden\" name=\"hid\" value=\"$hid\">
+	<input type=\"hidden\" name=\"gatewayaddress\" value=\"$gatewayaddress\">
 	<input type=\"hidden\" name=\"redir\" value=\"$requested\">
 	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>Name<br><br>
 	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>Email<br><br>
@@ -303,7 +307,6 @@ fi
 
 # Output the page footer
 echo -e "$footer"
-
 # The output of this script could of course be much more complex and
 # could easily be used to conduct a dialogue with the client user.
 #

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -7,6 +7,37 @@
 # This is changed to bash automatically by Makefile for Debian
 #
 
+
+# Customise the Logfile location:
+#
+# mountpoint is the mount point for the storage the log is to be kept on
+#
+# /tmp on OpenWrt is tmpfs (ram disk) and does not survive a reboot.
+#
+# /run on Raspbian is also tmpfs and also does not survive a reboot.
+#
+# These choices for OpenWrt and Raspbian are a good default for testing purposes
+# as long term use on internal flash could cause memory wear
+# In a production system, use the mount point of a usb drive for example
+#
+#
+# logdir is the directory path for the log file
+#
+#
+# logname is the name of the log file
+#
+
+#For Openwrt:
+mountpoint="/tmp"
+logdir="/tmp/ndslog/"
+logname="ndslog.log"
+
+#For Raspbian:
+#mountpoint="/run"
+#logdir="/run/ndslog/"
+#logname="ndslog.log"
+
+
 # functions:
 
 htmlentityencode() {
@@ -47,7 +78,13 @@ get_client_zone () {
 }
 
 write_log () {
-	logfile="/tmp/ndslog.log"
+
+	if [ ! -d "$logdir" ]; then
+		mkdir -p "$logdir"
+	fi
+
+	logfile="$logdir""$logname"
+	awkcmd="awk ""'\$6==""\"$mountpoint\"""{print \$4}'"
 	min_freespace_to_log_ratio=10
 	datetime=$(date)
 
@@ -57,7 +94,7 @@ write_log () {
 
 	ndspid=$(ps | grep nodogsplash | awk -F ' ' 'NR==2 {print $1}')
 	filesize=$(ls -s -1 $logfile | awk -F' ' '{print $1}')
-	available=$(df |grep /tmp | awk -F ' ' '$6=="/tmp"{print $4}')
+	available=$(df | grep "$mountpoint" | eval "$awkcmd")
 	sizeratio=$(($available/$filesize))
 
 	if [ $sizeratio -ge $min_freespace_to_log_ratio ]; then

--- a/forward_authentication_service/binauth/binauth_log.sh
+++ b/forward_authentication_service/binauth/binauth_log.sh
@@ -57,7 +57,7 @@ write_log () {
 #
 action=$1
 
-if [ $action == "auth_client" ]; then
+if [ $action = "auth_client" ]; then
 	#
 	# The redir parameter is sent to this script as the fifth command line argument in url-encoded form.
 	#

--- a/forward_authentication_service/libs/get_client_interface.sh
+++ b/forward_authentication_service/libs/get_client_interface.sh
@@ -27,7 +27,7 @@ mac=$1
 
 # exit if mac not passed
 
-if [  $(echo "$mac" | awk -F ':' '{print NF}') != 6 ]; then
+if [  $(echo "$mac" | awk -F ':' '{print NF}') -ne 6 ]; then
 	echo "
   Usage: get_client_interface.sh [clientmac]
 

--- a/forward_authentication_service/libs/get_client_interface.sh
+++ b/forward_authentication_service/libs/get_client_interface.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 #Copyright (C) The Nodogsplash Contributors 2004-2020
-#Copyright (C) Blue Wave Projects and Services 2015-2019
+#Copyright (C) BlueWave Projects and Services 2015-2020
 #This software is released under the GNU GPL license.
+#
+# Warning - shebang sh is for compatibliity with busybox ash (eg on OpenWrt)
+# This is changed to bash automatically by Makefile for Debian
+#
+
 
 pid=$(ps | grep get_client_interface | awk -F ' ' 'NR==2 {print $1}')
 

--- a/forward_authentication_service/libs/get_client_token.sh
+++ b/forward_authentication_service/libs/get_client_token.sh
@@ -36,7 +36,7 @@ wait_for_ndsctl () {
 
 		sleep 1
 
-		if [ $i == $timeout ] ; then
+		if [ $i = $timeout ] ; then
 			pid=$(ps | grep get_client_token | awk -F ' ' 'NR==2 {print $1}')
 			echo "ndsctl is busy or locked" | logger -p "daemon.warn" -s -t "NDS-Library[$pid]"
 			exit 1

--- a/forward_authentication_service/libs/get_client_token.sh
+++ b/forward_authentication_service/libs/get_client_token.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 #Copyright (C) The Nodogsplash Contributors 2004-2020
-#Copyright (C) Blue Wave Projects and Services 2015-2019
+#Copyright (C) BlueWave Projects and Services 2015-2020
 #This software is released under the GNU GPL license.
+#
+# Warning - shebang sh is for compatibliity with busybox ash (eg on OpenWrt)
+# This is changed to bash automatically by Makefile for Debian
+#
 
 # ip address of client is passed as a command line argument
 clientip=$1

--- a/forward_authentication_service/libs/unescape.sh
+++ b/forward_authentication_service/libs/unescape.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 #Copyright (C) The Nodogsplash Contributors 2004-2020
-#Copyright (C) Blue Wave Projects and Services 2015-2020
+#Copyright (C) BlueWave Projects and Services 2015-2020
 #This software is released under the GNU GPL license.
+#
+# Warning - shebang sh is for compatibliity with busybox ash (eg on OpenWrt)
+# This is changed to bash automatically by Makefile for Debian
+#
 
 option="$1"
 inputstr="$2"

--- a/forward_authentication_service/libs/unescape.sh
+++ b/forward_authentication_service/libs/unescape.sh
@@ -18,12 +18,12 @@ usage="
     [-option] is unescape type, currently -url only
 "
 
-if [ "$option" == "-url" ]; then
+if [ "$option" = "-url" ]; then
 	printf "${inputstr//%/\\x}"
 	exit 0
 fi
 
-if [ "$option" == "" ] || [ "$option" == "-h" ] || [ "$option" == "-help" ]; then
+if [ "$option" = "" ] || [ "$option" = "-h" ] || [ "$option" = "-help" ]; then
 	echo "$usage"
 	exit 0
 else

--- a/openwrt/nodogsplash/files/etc/config/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/config/nodogsplash
@@ -33,6 +33,16 @@ config nodogsplash
 	#
 	option login_option_enabled '0'
 
+	# MHD Unescape callback
+	# MHD has a built in unescape function that urldecodes incoming queries from browsers
+	# This option allows an external unescape script to be enabled
+	# The script must be named unescape.sh, be present in /usr/lib/nodogsplash/ and be executable.
+	# A standard unescape.sh script is installed by default
+	# Set to 1 to enable this option, 0 to disable
+	# default is disabled
+	option unescape_callback_enabled '0'
+
+
 	# WebRoot
 	# Default: /etc/nodogsplash/htdocs
 	#

--- a/openwrt/nodogsplash/files/etc/init.d/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/init.d/nodogsplash
@@ -142,7 +142,7 @@ generate_uci_config() {
   addline "GatewayInterface $ifname"
 
   for option in preauth binauth fasport faskey fasremotefqdn fasremoteip faspath fas_secure_enabled \
-    login_option_enabled daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
+    login_option_enabled unescape_callback_enabled daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
     gatewayaddress gatewayport webroot splashpage statuspage \
     redirecturl sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue trafficcontrol downloadlimit uploadlimit \

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -35,6 +35,15 @@ GatewayInterface br-lan
 #
 login_option_enabled 0
 
+# MHD Unescape callback
+# MHD has a built in unescape function that urldecodes incoming queries from browsers
+# This option allows an external unescape script to be enabled
+# The script must be named unescape.sh, be present in /usr/lib/nodogsplash/ and be executable.
+# A standard unescape.sh script is installed by default
+# Set to 1 to enable this option, 0 to disable
+# default is disabled
+#
+unescape_callback_enabled 0
 
 # Option: WebRoot
 # Default: /etc/nodogsplash/htdocs

--- a/src/conf.c
+++ b/src/conf.c
@@ -83,6 +83,7 @@ typedef enum {
 	oFasURL,
 	oFasSSL,
 	oLoginOptionEnabled,
+	oUnescapeCallbackEnabled,
 	oFasSecureEnabled,
 	oHTTPDMaxConn,
 	oWebRoot,
@@ -139,6 +140,7 @@ static const struct {
 	{ "fasurl", oFasURL },
 	{ "fasssl", oFasSSL },
 	{ "login_option_enabled", oLoginOptionEnabled },
+	{ "unescape_callback_enabled", oUnescapeCallbackEnabled },
 	{ "fas_secure_enabled", oFasSecureEnabled },
 	{ "faspath", oFasPath },
 	{ "webroot", oWebRoot },
@@ -213,6 +215,7 @@ config_init(void)
 	config.fas_port = DEFAULT_FASPORT;
 	config.fas_key = NULL;
 	config.login_option_enabled = DEFAULT_LOGIN_OPTION_ENABLED;
+	config.unescape_callback_enabled = DEFAULT_UNESCAPE_CALLBACK_ENABLED;
 	config.fas_secure_enabled = DEFAULT_FAS_SECURE_ENABLED;
 	config.fas_remoteip = NULL;
 	config.fas_remotefqdn = NULL;
@@ -793,6 +796,13 @@ config_read(const char *filename)
 			break;
 		case oLoginOptionEnabled:
 			if (sscanf(p1, "%d", &config.login_option_enabled) < 1) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(1);
+			}
+			break;
+		case oUnescapeCallbackEnabled:
+			if (sscanf(p1, "%d", &config.unescape_callback_enabled) < 1) {
 				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
 				debug(LOG_ERR, "Exiting...");
 				exit(1);

--- a/src/conf.h
+++ b/src/conf.h
@@ -56,6 +56,7 @@
 #define DEFAULT_GATEWAYPORT 2050
 #define DEFAULT_FASPORT 0
 #define DEFAULT_LOGIN_OPTION_ENABLED 0
+#define DEFAULT_UNESCAPE_CALLBACK_ENABLED 0
 #define DEFAULT_FAS_SECURE_ENABLED 1
 #define DEFAULT_FASPATH "/"
 #define DEFAULT_REMOTE_AUTH_PORT 80
@@ -155,6 +156,7 @@ typedef struct {
 	unsigned int gw_port;		/**< @brief Port the webserver will run on */
 	unsigned int fas_port;		/**< @brief Port the fas server will run on */
 	int login_option_enabled;	/**< @brief Use default PreAuth Login script  */
+	int unescape_callback_enabled;	/**< @brief Enable external MHD unescape callback script  */
 	int fas_secure_enabled;		/**< @brief Enable Secure FAS */
 	char *fas_path;			/**< @brief Path to forward authentication page of FAS */
 	char *fas_key;			/**< @brief AES key for FAS */

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -1222,6 +1222,7 @@ static void replace_variables(
 	char *denyaction = NULL;
 	char *authaction = NULL;
 	char *authtarget = NULL;
+	char htmlencoded[64] = {0};
 
 	sprintf(clientupload, "%llu", client->counters.outgoing);
 	sprintf(clientdownload, "%llu", client->counters.incoming);
@@ -1236,6 +1237,8 @@ static void replace_variables(
 	safe_asprintf(&authtarget, "http://%s/%s/?tok=%s&amp;redir=%s",
 		config->gw_address, config->authdir, client->token, redirect_url);
 
+	htmlentityencode(htmlencoded, sizeof(htmlencoded), config->gw_name, strlen(config->gw_name));
+
 	struct template vars[] = {
 		{"authaction", authaction},
 		{"denyaction", denyaction},
@@ -1245,7 +1248,7 @@ static void replace_variables(
 		{"clientupload", clientupload},
 		{"clientdownload", clientdownload},
 		{"gatewaymac", config->gw_mac},
-		{"gatewayname", config->gw_name},
+		{"gatewayname", htmlencoded},
 		{"maxclients", maxclients},
 		{"nclients", nclients},
 		{"redir", redirect_url},

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -576,7 +576,7 @@ static int authenticated(struct MHD_Connection *connection,
 			free(fasurl);
 			return ret;
 		} else if (config->fas_port && config->preauth) {
-			safe_asprintf(&fasurl, "?clientip=%s%sgatewayname=%s%sgatewayaddress%s%sstatus=authenticated",
+			safe_asprintf(&fasurl, "?clientip=%s%sgatewayname=%s%sgatewayaddress=%s%sstatus=authenticated",
 				client->ip, QUERYSEPARATOR, config->gw_name, QUERYSEPARATOR,  config->gw_address, QUERYSEPARATOR);
 			debug(LOG_DEBUG, "fasurl %s", fasurl);
 			ret = show_preauthpage(connection, fasurl);
@@ -646,7 +646,7 @@ static int show_preauthpage(struct MHD_Connection *connection, const char *query
 		return send_error(connection, 503);
 	}
 
-	MHD_add_response_header(response, "Content-Type", "text/html");
+	MHD_add_response_header(response, "Content-Type", "text/html; charset=utf-8");
 	ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
 	MHD_destroy_response(response);
 	return ret;

--- a/src/http_microhttpd_utils.c
+++ b/src/http_microhttpd_utils.c
@@ -20,6 +20,68 @@
 #include <ctype.h>
 #include "debug.h"
 
+/* blen is the size of buf; slen is the length of src.	The input-string need
+** not be, and the output string will not be, null-terminated.	Returns the
+** length of the encoded string, or -1 on error (buffer overflow) */
+int htmlentityencode(char *buf, int blen, const char *src, int slen)
+{
+	int i;
+	int len = 0;
+	static const char hex[] = "0123456789abcdef";
+
+	for (i = 0; (i < slen) && (len < blen); i++) {
+
+		if ((len+5) <= blen) {
+			if (src[i] == '"') {
+				buf[len++] = '&';
+				buf[len++] = '#';
+				buf[len++] = '3';
+				buf[len++] = '4';
+				buf[len++] = ';';
+
+			} else if (src[i] == '#') {
+				buf[len++] = '&';
+				buf[len++] = '#';
+				buf[len++] = '3';
+				buf[len++] = '5';
+				buf[len++] = ';';
+
+			} else if (src[i] == '\'') {
+				buf[len++] = '&';
+				buf[len++] = '#';
+				buf[len++] = '3';
+				buf[len++] = '9';
+				buf[len++] = ';';
+
+			} else if (src[i] == '<') {
+				buf[len++] = '&';
+				buf[len++] = '#';
+				buf[len++] = '6';
+				buf[len++] = '0';
+				buf[len++] = ';';
+
+			} else if (src[i] == '>') {
+				buf[len++] = '&';
+				buf[len++] = '#';
+				buf[len++] = '6';
+				buf[len++] = '2';
+				buf[len++] = ';';
+
+			} else {
+				buf[len++] = src[i];
+			}
+		} else {
+			len = -1;
+			debug(LOG_ERR, "Buffer overflow in htmlentityencode");
+			break;
+		}
+	}
+
+	debug(LOG_INFO, "HTML Entity encoded string: %s, length: %d", buf, len);
+	return (i == slen) ? len : -1;
+}
+
+
 /* blen is the size of buf; slen is the length of src. The input-string need
 ** not be, and the output string will not be, null-terminated. Returns the
 ** length of the decoded string, -1 on buffer overflow, -2 on malformed string. */

--- a/src/http_microhttpd_utils.h
+++ b/src/http_microhttpd_utils.h
@@ -56,6 +56,7 @@ struct uh_addr {
 #define __printf(a, b)
 #endif
 
+int htmlentityencode(char *buf, int blen, const char *src, int slen);
 int uh_urldecode(char *buf, int blen, const char *src, int slen);
 int uh_urlencode(char *buf, int blen, const char *src, int slen);
 int uh_b64decode(char *buf, int blen, const void *src, int slen);

--- a/src/main.c
+++ b/src/main.c
@@ -267,19 +267,39 @@ main_loop(void)
 	debug(LOG_NOTICE, "Detected gateway %s at %s (%s)", config->gw_interface, config->gw_ip, config->gw_mac);
 
 	/* Initializes the web server */
-	if ((webserver = MHD_start_daemon(MHD_USE_EPOLL_INTERNALLY | MHD_USE_TCP_FASTOPEN,
-							config->gw_port,
-							NULL, NULL,
-							libmicrohttpd_cb, NULL,
-							MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int) 120,
-							MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
-							MHD_OPTION_UNESCAPE_CALLBACK, unescape, NULL,
-							MHD_OPTION_END)) == NULL) {
-		debug(LOG_ERR, "Could not create web server: %s", strerror(errno));
-		exit(1);
+
+	if (config->unescape_callback_enabled == 0) {
+		debug(LOG_NOTICE, "MHD Unescape Callback is Disabled");
+		if ((webserver = MHD_start_daemon(MHD_USE_EPOLL_INTERNALLY | MHD_USE_TCP_FASTOPEN,
+								config->gw_port,
+								NULL, NULL,
+								libmicrohttpd_cb, NULL,
+								MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int) 120,
+								MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
+								MHD_OPTION_END)) == NULL) {
+			debug(LOG_ERR, "Could not create web server: %s", strerror(errno));
+			exit(1);
+		}
+
+	} else {
+		debug(LOG_NOTICE, "MHD Unescape Callback is Enabled");
+		if ((webserver = MHD_start_daemon(MHD_USE_EPOLL_INTERNALLY | MHD_USE_TCP_FASTOPEN,
+								config->gw_port,
+								NULL, NULL,
+								libmicrohttpd_cb, NULL,
+								MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int) 120,
+								MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
+								MHD_OPTION_UNESCAPE_CALLBACK, unescape, NULL,
+								MHD_OPTION_END)) == NULL) {
+			debug(LOG_ERR, "Could not create web server: %s", strerror(errno));
+			exit(1);
+		}
 	}
+
 	/* TODO: set listening socket */
 	debug(LOG_NOTICE, "Created web server on %s", config->gw_address);
+
+
 
 	if (config->login_option_enabled > 0) {
 		debug(LOG_NOTICE, "Login option is Enabled.\n");


### PR DESCRIPTION
This PR contains the following commits:
 * Preauth: fix status authenticated - missing "=" and add utf-8 to the header
 * Preauth: Support hashed id (hid) if sent by NDS; Fix status=authenticated
 * Add shebang warning
 * Add htmlentityencode function, encode gatewayname in templated splash page
 * Add option: option unescape_callback_enabled
 * PreAuth: htmlentity encode gatewayname on login page
 * BinAuth: Prevent ndsctl from running if called from a Binauth script.
 * Library scripts: Minor changes for better portability
 * PreAuth and BinAuth: Add simple customisation of log file location.

The major enhancement is the addition of `option unescape_callback_enabled`
This defaults to disabled. When enabled, escaped query sting segments received from client CPD are sent to the external script unescape.sh
The installed unescape.sh provides nothing more than the MHD builtin, but its inclusion as an editable script allows advanced users to develop custom unescape functionality such as character translation of form data.