### PR TITLE
Force minumum version of libmicrohttpd (MHD)

### DIFF
--- a/openwrt/nodogsplash/files/etc/init.d/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/init.d/nodogsplash
@@ -113,6 +113,43 @@ generate_uci_config() {
   local download
   local upload
 
+# Check libmicrohttpd version
+  local minversion="0.9.69"
+  local oldver="libmicrohttpd is out of date, please upgrade to at least version $minversion, Exiting...."
+
+  if [ -f "/usr/lib/opkg/info/libmicrohttpd-no-ssl.control" ]; then
+    local cpath="/usr/lib/opkg/info/libmicrohttpd-no-ssl.control"
+
+  elif [ -f "/usr/lib/opkg/info/libmicrohttpd-ssl.control" ]; then
+    local cpath="/usr/lib/opkg/info/libmicrohttpd-ssl.control"
+
+  else
+    echo "libmicrohttpd is not installed, Exiting...."
+    return 1
+  fi
+
+  local min_major=$(echo "$minversion" | awk -F '.' '{print $1}')
+  local min_minor=$(echo "$minversion" | awk -F '.' '{print $2}')
+  local min_patch=$(echo "$minversion" | awk -F '.' '{print $3}' | awk -F '-' '{print $1}' )
+
+  local mhdver=$(grep "Ver" "$cpath" | awk -F 'Version: ' '{print $2}')
+  local major=$(echo "$mhdver" | awk -F '.' '{print $1}')
+  local minor=$(echo "$mhdver" | awk -F '.' '{print $2}')
+  local patch=$(echo "$mhdver" | awk -F '.' '{print $3}' | awk -F '-' '{print $1}' )
+
+  if [ $major -lt $min_major ]; then
+    echo "$oldver"
+    return 1
+
+  elif [ $minor -lt $min_minor ]; then
+    echo "$oldver"
+    return 1
+
+  elif [ $patch -lt $min_patch ]; then
+    echo "$oldver"
+    return 1
+  fi
+
   # Init config file content
   CONFIG="# auto-generated config file from /etc/config/nodogsplash"
 

--- a/src/main.c
+++ b/src/main.c
@@ -65,9 +65,9 @@
 
 #include <microhttpd.h>
 
-// Check for libmicrohttp version >= 0.9.51
-#if MHD_VERSION < 0x00095100
-#error libmicrohttp version >= 0.9.51 required
+// Check for libmicrohttp version
+#if MHD_VERSION < 0x00096900
+#error libmicrohttp version >= 0.9.69 required
 #endif
 
 /** XXX Ugly hack


### PR DESCRIPTION
See issue #515

The setting in main.c works only if NDS is compiled and installed in place.

If creating a package however, microhttpd.h is embedded as an include
leaving no way for NDS to discover the installed MHD version.

This commit uses the NDS init.d script on Openwrt to determine the
installed MHD version.

opkg cannot be used to determine the MHD version as on installing (with opkg)
an opkg lock error is generated.

If in the future, NDS was to be added to other Linux official package repo's
(eg Debian), similar installed version detection would have to be done.