### PR TITLE
Add option use_outdated_mhd

### DIFF
--- a/openwrt/nodogsplash/files/etc/config/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/config/nodogsplash
@@ -33,6 +33,15 @@ config nodogsplash
 	#
 	option login_option_enabled '0'
 
+	# Use outdated libmicrohttpd (MHD)
+	# Older versions of MHD convert & and + characters to spaces when present in form data
+	# This can make a PreAuth or BinAuth impossible to use for a client if form data contains either of these characters
+	# eg. in username or password
+	# MHD versions earlier than 0.9.69 are detected.
+	# If this option is set to 0 (default), NDS will terminate if MHD is earlier than 0.9.69
+	# If this option is set to 1, NDS will start but log an error.
+	option use_outdated_mhd '0'
+
 	# MHD Unescape callback
 	# MHD has a built in unescape function that urldecodes incoming queries from browsers
 	# This option allows an external unescape script to be enabled

--- a/openwrt/nodogsplash/files/etc/init.d/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/init.d/nodogsplash
@@ -142,7 +142,7 @@ generate_uci_config() {
   addline "GatewayInterface $ifname"
 
   for option in preauth binauth fasport faskey fasremotefqdn fasremoteip faspath fas_secure_enabled \
-    login_option_enabled unescape_callback_enabled daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
+    login_option_enabled use_outdated_mhd unescape_callback_enabled daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
     gatewayaddress gatewayport webroot splashpage statuspage \
     redirecturl sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue trafficcontrol downloadlimit uploadlimit \

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -35,6 +35,15 @@ GatewayInterface br-lan
 #
 login_option_enabled 0
 
+# Use outdated libmicrohttpd (MHD)
+# Older versions of MHD convert & and + characters to spaces when present in form data
+# This can make a PreAuth or BinAuth impossible to use for a client if form data contains either of these characters
+# eg. in username or password
+# MHD versions earlier than 0.9.69 are detected.
+# If this option is set to 0 (default), NDS will terminate if MHD is earlier than 0.9.69
+# If this option is set to 1, NDS will start but log an error.
+use_outdated_mhd 0
+
 # MHD Unescape callback
 # MHD has a built in unescape function that urldecodes incoming queries from browsers
 # This option allows an external unescape script to be enabled

--- a/src/conf.c
+++ b/src/conf.c
@@ -83,6 +83,7 @@ typedef enum {
 	oFasURL,
 	oFasSSL,
 	oLoginOptionEnabled,
+	oUseOutdatedMHD,
 	oUnescapeCallbackEnabled,
 	oFasSecureEnabled,
 	oHTTPDMaxConn,
@@ -140,6 +141,7 @@ static const struct {
 	{ "fasurl", oFasURL },
 	{ "fasssl", oFasSSL },
 	{ "login_option_enabled", oLoginOptionEnabled },
+	{ "use_outdated_mhd", oUseOutdatedMHD },
 	{ "unescape_callback_enabled", oUnescapeCallbackEnabled },
 	{ "fas_secure_enabled", oFasSecureEnabled },
 	{ "faspath", oFasPath },
@@ -216,6 +218,7 @@ config_init(void)
 	config.fas_port = DEFAULT_FASPORT;
 	config.fas_key = NULL;
 	config.login_option_enabled = DEFAULT_LOGIN_OPTION_ENABLED;
+	config.use_outdated_mhd = DEFAULT_USE_OUTDATED_MHD;
 	config.unescape_callback_enabled = DEFAULT_UNESCAPE_CALLBACK_ENABLED;
 	config.fas_secure_enabled = DEFAULT_FAS_SECURE_ENABLED;
 	config.fas_remoteip = NULL;
@@ -797,6 +800,13 @@ config_read(const char *filename)
 			break;
 		case oLoginOptionEnabled:
 			if (sscanf(p1, "%d", &config.login_option_enabled) < 1) {
+				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
+				debug(LOG_ERR, "Exiting...");
+				exit(1);
+			}
+			break;
+		case oUseOutdatedMHD:
+			if (sscanf(p1, "%d", &config.use_outdated_mhd) < 1) {
 				debug(LOG_ERR, "Bad arg %s to option %s on line %d in %s", p1, s, linenum, filename);
 				debug(LOG_ERR, "Exiting...");
 				exit(1);

--- a/src/conf.h
+++ b/src/conf.h
@@ -56,6 +56,7 @@
 #define DEFAULT_GATEWAYPORT 2050
 #define DEFAULT_FASPORT 0
 #define DEFAULT_LOGIN_OPTION_ENABLED 0
+#define DEFAULT_USE_OUTDATED_MHD 0
 #define DEFAULT_UNESCAPE_CALLBACK_ENABLED 0
 #define DEFAULT_FAS_SECURE_ENABLED 1
 #define DEFAULT_FASPATH "/"
@@ -157,6 +158,7 @@ typedef struct {
 	unsigned int gw_port;		/**< @brief Port the webserver will run on */
 	unsigned int fas_port;		/**< @brief Port the fas server will run on */
 	int login_option_enabled;	/**< @brief Use default PreAuth Login script  */
+	int use_outdated_mhd;		/**< @brief Use outdated libmicrohttpd  */
 	int unescape_callback_enabled;	/**< @brief Enable external MHD unescape callback script  */
 	int fas_secure_enabled;		/**< @brief Enable Secure FAS */
 	char *fas_path;			/**< @brief Path to forward authentication page of FAS */

--- a/src/main.c
+++ b/src/main.c
@@ -247,6 +247,7 @@ main_loop(void)
 	int major = 0;
 	int minor = 0;
 	int patch = 0;
+	int outdated = 0;
 	const char *version = MHD_get_version();
 
 	debug(LOG_NOTICE, "MHD version is %s", version);
@@ -254,24 +255,16 @@ main_loop(void)
 	if (sscanf(version, "%d.%d.%d", &major, &minor, &patch) == 3) {
 
 		if (major < MIN_MHD_MAJOR) {
-			debug(LOG_ERR, "libmicrohttpd is out of date, please upgrade to version %d.%d.%d or higher",
-				MIN_MHD_MAJOR, MIN_MHD_MINOR, MIN_MHD_PATCH);
-
-			if (config->use_outdated_mhd == 0) {
-				debug(LOG_ERR, "exiting...");
-				exit(1);
-			}
+			outdated = 1;
 
 		} else if (minor < MIN_MHD_MINOR) {
-			debug(LOG_ERR, "libmicrohttpd is out of date, please upgrade to version %d.%d.%d or higher",
-				MIN_MHD_MAJOR, MIN_MHD_MINOR, MIN_MHD_PATCH);
-
-			if (config->use_outdated_mhd == 0) {
-				debug(LOG_ERR, "exiting...");
-				exit(1);
-			}
+			outdated = 1;
 
 		} else if (patch < MIN_MHD_PATCH) {
+			outdated = 1;
+		}
+
+		if (outdated == 1) {
 			debug(LOG_ERR, "libmicrohttpd is out of date, please upgrade to version %d.%d.%d or higher",
 				MIN_MHD_MAJOR, MIN_MHD_MINOR, MIN_MHD_PATCH);
 
@@ -282,15 +275,14 @@ main_loop(void)
 		}
 	}
 
-
-
+	// Encode gatewayname
 	htmlentityencode(http_encoded, sizeof(http_encoded), config->gw_name, strlen(config->gw_name));
 	config->http_encoded_gw_name = http_encoded;
 
+	/* Set the time when nodogsplash started */
 	sysuptime = get_system_uptime ();
 	debug(LOG_INFO, "main: System Uptime is %li seconds", sysuptime);
 
-	/* Set the time when nodogsplash started */
 	if (!started_time) {
 		debug(LOG_INFO, "Setting started_time");
 		started_time = time(NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -65,10 +65,18 @@
 
 #include <microhttpd.h>
 
-// Check for libmicrohttp version >= 0.9.51
+/* Check for libmicrohttp version in compiler
+ *0.9.51 is the minimum version for NDS to work
+ */
 #if MHD_VERSION < 0x00095100
 #error libmicrohttp version >= 0.9.51 required
 #endif
+/* Check for libmicrohttp version at runtime
+ *0.9.69 is the minimum version to prevent loss of special characters in form data (BinAuth and PreAuth) 
+ */
+#define MIN_MHD_MAJOR 0
+#define MIN_MHD_MINOR 9
+#define MIN_MHD_PATCH 69
 
 /** XXX Ugly hack
  * We need to remember the thread IDs of threads that simulate wait with pthread_cond_timedwait
@@ -234,6 +242,47 @@ main_loop(void)
 	time_t sysuptime;
 
 	config = config_get_config();
+
+	// Check for libmicrohttp version at runtime, ie actual installed version
+	int major = 0;
+	int minor = 0;
+	int patch = 0;
+	const char *version = MHD_get_version();
+
+	debug(LOG_NOTICE, "MHD version is %s", version);
+
+	if (sscanf(version, "%d.%d.%d", &major, &minor, &patch) == 3) {
+
+		if (major < MIN_MHD_MAJOR) {
+			debug(LOG_ERR, "libmicrohttpd is out of date, please upgrade to version %d.%d.%d or higher",
+				MIN_MHD_MAJOR, MIN_MHD_MINOR, MIN_MHD_PATCH);
+
+			if (config->use_outdated_mhd == 0) {
+				debug(LOG_ERR, "exiting...");
+				exit(1);
+			}
+
+		} else if (minor < MIN_MHD_MINOR) {
+			debug(LOG_ERR, "libmicrohttpd is out of date, please upgrade to version %d.%d.%d or higher",
+				MIN_MHD_MAJOR, MIN_MHD_MINOR, MIN_MHD_PATCH);
+
+			if (config->use_outdated_mhd == 0) {
+				debug(LOG_ERR, "exiting...");
+				exit(1);
+			}
+
+		} else if (patch < MIN_MHD_PATCH) {
+			debug(LOG_ERR, "libmicrohttpd is out of date, please upgrade to version %d.%d.%d or higher",
+				MIN_MHD_MAJOR, MIN_MHD_MINOR, MIN_MHD_PATCH);
+
+			if (config->use_outdated_mhd == 0) {
+				debug(LOG_ERR, "exiting...");
+				exit(1);
+			}
+		}
+	}
+
+
 
 	htmlentityencode(http_encoded, sizeof(http_encoded), config->gw_name, strlen(config->gw_name));
 	config->http_encoded_gw_name = http_encoded;


### PR DESCRIPTION
See issue #515

MHD_get_version is used to determine the installed (runtime) version of
libmicrohttpd (MHD).
If the version is earlier than 0.9.69, then by default, NDS will terminate.

However, if option use_outdated_mhd is set to 1, NDS starts normally
but logs an error.

Signed-off-by: Rob White <rob@blue-wave.net>