### PR TITLE
url-encode gatewayname on startup

### DIFF
--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -134,8 +134,7 @@ write_log () {
 	sizeratio=$(($available/$filesize))
 
 	if [ $sizeratio -ge $min_freespace_to_log_ratio ]; then
-		htmlentitydecode "$username"
-		userinfo="username=$entitydecoded, emailAddress=$emailaddr"
+		userinfo="username=$username, emailAddress=$emailaddr"
 		clientinfo="macaddress=$clientmac, clientzone=$client_zone, useragent=$user_agent"
 		echo "$datetime, $userinfo, $clientinfo" >> $logfile
 	else
@@ -228,7 +227,7 @@ htmlentityencode "$gatewayname"
 gatewaynamehtml=$entityencoded
 username=$(printf "${username//%/\\x}")
 htmlentityencode "$username"
-username=$entityencoded
+usernamehtml=$entityencoded
 emailaddr=$(printf "${emailaddr//%/\\x}")
 
 #requested might have trailing comma space separated, user defined parameters - so remove them as well as decoding
@@ -310,7 +309,7 @@ login_form="
 	<input type=\"hidden\" name=\"hid\" value=\"$hid\">
 	<input type=\"hidden\" name=\"gatewayaddress\" value=\"$gatewayaddress\">
 	<input type=\"hidden\" name=\"redir\" value=\"$requested\">
-	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>Name<br><br>
+	<input type=\"text\" name=\"username\" value=\"$usernamehtml\" autocomplete=\"on\" ><br>Name<br><br>
 	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>Email<br><br>
 	<input type=\"submit\" value=\"Continue\" >
 	</form><hr>

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -98,8 +98,7 @@ write_log () {
 	sizeratio=$(($available/$filesize))
 
 	if [ $sizeratio -ge $min_freespace_to_log_ratio ]; then
-		htmlentitydecode "$username"
-		userinfo="username=$entitydecoded, emailAddress=$emailaddr"
+		userinfo="username=$username, emailAddress=$emailaddr"
 		clientinfo="macaddress=$clientmac, clientzone=$client_zone, useragent=$user_agent"
 		echo "$datetime, $userinfo, $clientinfo" >> $logfile
 	else
@@ -192,7 +191,7 @@ htmlentityencode "$gatewayname"
 gatewaynamehtml=$entityencoded
 username=$(printf "${username//%/\\x}")
 htmlentityencode "$username"
-username=$entityencoded
+usernamehtml=$entityencoded
 emailaddr=$(printf "${emailaddr//%/\\x}")
 
 #requested might have trailing comma space separated, user defined parameters - so remove them as well as decoding
@@ -331,7 +330,7 @@ else
 	# the client user continues, so now is the time to deliver your message.
 
 	echo "<big-red>Thankyou!</big-red>"
-	echo "<br><b>Welcome $username</b>"
+	echo "<br><b>Welcome $usernamehtml</b>"
 
 	# Add your message here:
 	# You could retrieve text or images from a remote server using wget or curl

--- a/src/conf.c
+++ b/src/conf.c
@@ -210,6 +210,7 @@ config_init(void)
 	config.maxclients = DEFAULT_MAXCLIENTS;
 	config.gw_name = safe_strdup(DEFAULT_GATEWAYNAME);
 	config.http_encoded_gw_name = NULL;
+	config.url_encoded_gw_name = NULL;
 	config.gw_interface = NULL;
 	config.gw_iprange = safe_strdup(DEFAULT_GATEWAY_IPRANGE);
 	config.gw_address = NULL;

--- a/src/conf.h
+++ b/src/conf.h
@@ -150,6 +150,7 @@ typedef struct {
 	int maxclients;			/**< @brief Maximum number of clients allowed */
 	char *gw_name;			/**< @brief Name of the gateway; e.g. its SSID or a unique identifier for use in a remote FAS */
 	char *http_encoded_gw_name;	/**< @brief http encoded name of the gateway, used as a templated variable in splash.htm */
+	char *url_encoded_gw_name;	/**< @brief url encoded name of the gateway used as variable in Preauth */
 	char *gw_interface;		/**< @brief Interface we will manage */
 	char *gw_iprange;		/**< @brief IP range on gw_interface we will manage */
 	char *gw_ip;			/**< @brief Internal IP (v4 or v6) for our web server */

--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -582,14 +582,14 @@ static int authenticated(struct MHD_Connection *connection,
 	if (check_authdir_match(url, config->authdir)) {
 		if (config->fas_port && !config->preauth) {
 			safe_asprintf(&fasurl, "%s?clientip=%s&gatewayname=%s&gatewayaddress=%s&status=authenticated",
-				config->fas_url, client->ip, config->gw_name, config->gw_address);
+				config->fas_url, client->ip, config->url_encoded_gw_name, config->gw_address);
 			debug(LOG_DEBUG, "fasurl %s", fasurl);
 			ret = send_redirect_temp(connection, client, fasurl);
 			free(fasurl);
 			return ret;
 		} else if (config->fas_port && config->preauth) {
 			safe_asprintf(&fasurl, "?clientip=%s%sgatewayname=%s%sgatewayaddress=%s%sstatus=authenticated",
-				client->ip, QUERYSEPARATOR, config->gw_name, QUERYSEPARATOR,  config->gw_address, QUERYSEPARATOR);
+				client->ip, QUERYSEPARATOR, config->url_encoded_gw_name, QUERYSEPARATOR,  config->gw_address, QUERYSEPARATOR);
 			debug(LOG_DEBUG, "fasurl %s", fasurl);
 			ret = show_preauthpage(connection, fasurl);
 			free(fasurl);
@@ -602,7 +602,7 @@ static int authenticated(struct MHD_Connection *connection,
 	if (check_authdir_match(url, config->preauthdir)) {
 		if (config->fas_port) {
 			safe_asprintf(&fasurl, "?clientip=%s&gatewayname=%s&gatewayaddress=%s&status=authenticated",
-				client->ip, config->gw_name, config->gw_address);
+				client->ip, config->url_encoded_gw_name, config->gw_address);
 			debug(LOG_DEBUG, "fasurl %s", fasurl);
 			ret = show_preauthpage(connection, fasurl);
 			free(fasurl);
@@ -898,7 +898,7 @@ static char *construct_querystring(t_client *client, char *originurl, char *quer
 	s_config *config = config_get_config();
 
 	if (config->fas_secure_enabled == 0) {
-		snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s&tok=%s", client->ip, config->gw_name, client->token);
+		snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s&tok=%s", client->ip, config->url_encoded_gw_name, client->token);
 
 	} else if (config->fas_secure_enabled == 1) {
 
@@ -906,9 +906,9 @@ static char *construct_querystring(t_client *client, char *originurl, char *quer
 				hash_str(hash, sizeof(hash), client->token);
 				debug(LOG_INFO, "hid=%s", hash);
 				snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s&hid=%s&gatewayaddress=%s",
-					client->ip, config->gw_name, hash, config->gw_address);
+					client->ip, config->url_encoded_gw_name, hash, config->gw_address);
 			} else {
-				snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s", client->ip, config->gw_name);
+				snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s", client->ip, config->url_encoded_gw_name);
 			}
 
 	} else if (config->fas_secure_enabled == 2) {
@@ -925,7 +925,7 @@ static char *construct_querystring(t_client *client, char *originurl, char *quer
 			clientif);
 
 	} else {
-		snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s", client->ip, config->gw_name);
+		snprintf(querystr, QUERYMAXLEN, "?clientip=%s&gatewayname=%s", client->ip, config->url_encoded_gw_name);
 	}
 
 	return querystr;

--- a/src/http_microhttpd_utils.c
+++ b/src/http_microhttpd_utils.c
@@ -46,11 +46,25 @@ int htmlentityencode(char *buf, int blen, const char *src, int slen)
 				buf[len++] = '5';
 				buf[len++] = ';';
 
+			} else if (src[i] == '&') {
+				buf[len++] = '&';
+				buf[len++] = '#';
+				buf[len++] = '3';
+				buf[len++] = '8';
+				buf[len++] = ';';
+
 			} else if (src[i] == '\'') {
 				buf[len++] = '&';
 				buf[len++] = '#';
 				buf[len++] = '3';
 				buf[len++] = '9';
+				buf[len++] = ';';
+
+			} else if (src[i] == '+') {
+				buf[len++] = '&';
+				buf[len++] = '#';
+				buf[len++] = '4';
+				buf[len++] = '3';
 				buf[len++] = ';';
 
 			} else if (src[i] == '<') {

--- a/src/main.c
+++ b/src/main.c
@@ -238,7 +238,7 @@ main_loop(void)
 	char *preauth_dir = NULL;
 	struct stat sb;
 	char loginscript[] = "/usr/lib/nodogsplash/login.sh";
-	char http_encoded[64] = {0};
+	char gw_name_encoded[64] = {0};
 	time_t sysuptime;
 
 	config = config_get_config();
@@ -276,8 +276,11 @@ main_loop(void)
 	}
 
 	// Encode gatewayname
-	htmlentityencode(http_encoded, sizeof(http_encoded), config->gw_name, strlen(config->gw_name));
-	config->http_encoded_gw_name = http_encoded;
+	htmlentityencode(gw_name_encoded, sizeof(gw_name_encoded), config->gw_name, strlen(config->gw_name));
+	config->http_encoded_gw_name = gw_name_encoded;
+
+	uh_urlencode(gw_name_encoded, sizeof(gw_name_encoded), config->gw_name, strlen(config->gw_name));
+	config->url_encoded_gw_name = gw_name_encoded;
 
 	/* Set the time when nodogsplash started */
 	sysuptime = get_system_uptime ();


### PR DESCRIPTION
This PR ensures Gatewayname is passed in the querystring in its urlencoded form.
In addition it expands htmlentity encoding to include & and +
Finally, included preauth scripts are modified to allow special characters in username.

- url-encode gatewayname on startup
- Add htmlentities "&" and "+"
- Preauth: Allow special characters in username