### PR TITLE
Fix: Allow use of "#" and "'" (single quote/asterisk) in gatewayname

### DIFF
--- a/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth-remote-image.sh
@@ -305,7 +305,7 @@ footer="
 login_form="
 	<form action=\"/nodogsplash_preauth/\" method=\"get\">
 	<input type=\"hidden\" name=\"clientip\" value=\"$clientip\">
-	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewayname\">
+	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewaynamehtml\">
 	<input type=\"hidden\" name=\"hid\" value=\"$hid\">
 	<input type=\"hidden\" name=\"gatewayaddress\" value=\"$gatewayaddress\">
 	<input type=\"hidden\" name=\"redir\" value=\"$requested\">

--- a/forward_authentication_service/PreAuth/demo-preauth.sh
+++ b/forward_authentication_service/PreAuth/demo-preauth.sh
@@ -258,11 +258,11 @@ footer="
 login_form="
 	<form action=\"/nodogsplash_preauth/\" method=\"get\">
 	<input type=\"hidden\" name=\"clientip\" value=\"$clientip\">
-	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewayname\">
+	<input type=\"hidden\" name=\"gatewayname\" value=\"$gatewaynamehtml\">
 	<input type=\"hidden\" name=\"hid\" value=\"$hid\">
 	<input type=\"hidden\" name=\"gatewayaddress\" value=\"$gatewayaddress\">
 	<input type=\"hidden\" name=\"redir\" value=\"$requested\">
-	<input type=\"text\" name=\"username\" value=\"$username\" autocomplete=\"on\" ><br>Name<br><br>
+	<input type=\"text\" name=\"username\" value=\"$usernamehtml\" autocomplete=\"on\" ><br>Name<br><br>
 	<input type=\"email\" name=\"emailaddr\" value=\"$emailaddr\" autocomplete=\"on\" ><br>Email<br><br>
 	<input type=\"submit\" value=\"Continue\" >
 	</form><hr>

--- a/openwrt/nodogsplash/files/etc/config/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/config/nodogsplash
@@ -74,8 +74,31 @@ config nodogsplash
 	#
 	#option gatewayport '2050'
 
-
+	# GatewayName
+	# Default: NoDogSplash
+	#
+	# gatewayname is used as an identifier for the instance of NoDogSplash
+	#
+	# It is displayed on the default static splash page and the default preauth login script.
+	#
+	# It is particularly useful in the case of a singe remote FAS server that serves multiple
+	# NoDogSplash sites, allowing the FAS to customise its response for each site.
+	#
+	# Note: The single quote (or apostrophe) character ('), cannot be used in the gatewayname.
+	# If it is required, use the htmlentity &#39; instead.
+	#
+	# For example:
+	# option gatewayname 'Bill's WiFi' is invalid.
+	# Instead use:
+	# option gatewayname 'Bill&#39;s WiFi'
+	#
 	option gatewayname 'OpenWrt Nodogsplash'
+
+	# MaxClients
+	# Default 20
+	# The maximum number of clients allowed to connect
+	# This should be less than or equal to the number of allowed DHCP leases
+	# For example:
 	option maxclients '250'
 
 	# Enables debug output (0-3)

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -1,6 +1,10 @@
 #
 # Nodogsplash Configuration File
 #
+# The "#" character at the beginning of a line indicates that the whole line is a comment.
+#
+# "#" characters within a line are assumed to be part of the configured option
+#
 
 # Option: GatewayInterface
 # Default: NONE
@@ -201,6 +205,26 @@ FirewallRuleSet users-to-router {
 # EmptyRuleSetPolicy trusted-users-to-router allow
 
 
+# GatewayName
+# Default: NoDogSplash
+#
+# gatewayname is used as an identifier for the instance of NoDogSplash
+#
+# It is displayed on the default static splash page and the default preauth login script.
+#
+# It is particularly useful in the case of a singe remote FAS server that serves multiple
+# NoDogSplash sites, allowing the FAS to customise its response for each site.
+#
+# Note: The single quote (or apostrophe) character ('), cannot be used in the gatewayname.
+# If it is required, use the htmlentity &#39; instead.
+#
+# For example:
+# GatewayName Bill's WiFi is invalid.
+# Instead use:
+# GatewayName Bill&#39;s WiFi
+#
+# GatewayName NoDogSplash
+
 # Option: GatewayName
 # Default: NoDogSplash
 #
@@ -214,10 +238,9 @@ FirewallRuleSet users-to-router {
 # Option: GatewayAddress
 # Default: Discovered from GatewayInterface
 #
-# This should be autodetected on an OpenWRT system, but if not:
-# Set GatewayAddress to the IP address of the router on
-# the GatewayInterface.  This is the address that the Nodogsplash
-# server listens on.
+# This should be autodetected and need not be specified.
+# If set here, it must be set to the IP address of the router on
+# the GatewayInterface. Setting incorrectly will result in failure of Nodogsplash.
 #
 # GatewayAddress 192.168.1.1
 
@@ -249,9 +272,7 @@ FirewallRuleSet users-to-router {
 #
 #	This functionality, ie displaying a particular web page as a final "Landing Page",
 #	can be achieved reliably using FAS, with NDS calling the previous "redirectURL" as the FAS page.
-
-# 
-# RedirectURL http://www.ilesansfil.org/
+#
 
 # Option: GatewayPort
 # Default: 2050

--- a/src/conf.c
+++ b/src/conf.c
@@ -661,25 +661,17 @@ Return a pointer to the first nonspace char in the string.
 static char*
 _strip_whitespace(char* p1)
 {
-	char *p2, *p3;
-
-	p3 = p1;
-	while ((p2 = strchr(p3,'#')) != 0) {  /* strip the comment */
-		/* but allow # to be escaped by \ */
-		if (p2 > p1 && (*(p2 - 1) == '\\')) {
-			p3 = p2 + 1;
-			continue;
-		}
-		*p2 = '\0';
-		break;
-	}
-
 	/* strip leading whitespace */
 	while(isspace(p1[0])) p1++;
+
+	/* strip comment lines */
+	if (p1[0] == '#') {
+		p1[0] = '\0';
+	}
+
 	/* strip trailing whitespace */
 	while(p1[0] != '\0' && isspace(p1[strlen(p1)-1]))
 		p1[strlen(p1)-1] = '\0';
-
 	return p1;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -238,7 +238,8 @@ main_loop(void)
 	char *preauth_dir = NULL;
 	struct stat sb;
 	char loginscript[] = "/usr/lib/nodogsplash/login.sh";
-	char gw_name_encoded[64] = {0};
+	char gw_name_entityencoded[QUERYMAXLEN] = {0};
+	char gw_name_urlencoded[QUERYMAXLEN] = {0};
 	time_t sysuptime;
 
 	config = config_get_config();
@@ -276,11 +277,11 @@ main_loop(void)
 	}
 
 	// Encode gatewayname
-	htmlentityencode(gw_name_encoded, sizeof(gw_name_encoded), config->gw_name, strlen(config->gw_name));
-	config->http_encoded_gw_name = gw_name_encoded;
+	htmlentityencode(gw_name_entityencoded, sizeof(gw_name_entityencoded), config->gw_name, strlen(config->gw_name));
+	config->http_encoded_gw_name = gw_name_entityencoded;
 
-	uh_urlencode(gw_name_encoded, sizeof(gw_name_encoded), config->gw_name, strlen(config->gw_name));
-	config->url_encoded_gw_name = gw_name_encoded;
+	uh_urlencode(gw_name_urlencoded, sizeof(gw_name_urlencoded), config->gw_name, strlen(config->gw_name));
+	config->url_encoded_gw_name = gw_name_urlencoded;
 
 	/* Set the time when nodogsplash started */
 	sysuptime = get_system_uptime ();


### PR DESCRIPTION
See issue #516

"#" is used as a comment indicator in nodogsplash.conf
This fix allows the character to be present as part of an option value.
If the character occurs at the beginning of the line,
the line will be considered as a comment.

"'" (single quote/asterisk) is used as a uci delimiter.
If this character is required in gatewayname then use the
htmlentity &#39; instead.
The default config files have been updated to reflect this.

The demo preauth scripts have been modified to ensure
gatewayname is properly escaped.


Signed-off-by: Rob White <rob@blue-wave.net>