### PR TITLE
ndsctl: add trusted devices list to json output.

### DIFF
--- a/openwrt/nodogsplash/files/etc/config/nodogsplash
+++ b/openwrt/nodogsplash/files/etc/config/nodogsplash
@@ -81,7 +81,7 @@ config nodogsplash
 	#
 	# It is displayed on the default static splash page and the default preauth login script.
 	#
-	# It is particularly useful in the case of a singe remote FAS server that serves multiple
+	# It is particularly useful in the case of a single remote FAS server that serves multiple
 	# NoDogSplash sites, allowing the FAS to customise its response for each site.
 	#
 	# Note: The single quote (or apostrophe) character ('), cannot be used in the gatewayname.

--- a/resources/nodogsplash.conf
+++ b/resources/nodogsplash.conf
@@ -212,7 +212,7 @@ FirewallRuleSet users-to-router {
 #
 # It is displayed on the default static splash page and the default preauth login script.
 #
-# It is particularly useful in the case of a singe remote FAS server that serves multiple
+# It is particularly useful in the case of a single remote FAS server that serves multiple
 # NoDogSplash sites, allowing the FAS to customise its response for each site.
 #
 # Note: The single quote (or apostrophe) character ('), cannot be used in the gatewayname.
@@ -222,16 +222,6 @@ FirewallRuleSet users-to-router {
 # GatewayName Bill's WiFi is invalid.
 # Instead use:
 # GatewayName Bill&#39;s WiFi
-#
-# GatewayName NoDogSplash
-
-# Option: GatewayName
-# Default: NoDogSplash
-#
-# Set  GatewayName to the name of your gateway.  This value
-# will be available as variable $gatewayname in the splash page source
-# and in status output from ndsctl, but otherwise doesn't matter.
-# If none is supplied, the value "NoDogSplash" is used.
 #
 # GatewayName NoDogSplash
 

--- a/src/util.c
+++ b/src/util.c
@@ -761,8 +761,13 @@ ndsctl_json_all(FILE *fp)
 {
 	t_client *client;
 	time_t now;
+	t_MAC *trust_mac;
+	s_config *config;
+	int count = 0;
 
 	now = time(NULL);
+
+	config = config_get_config();
 
 	/* Update the client's counters so info is current */
 	iptables_fw_counters_update();
@@ -790,6 +795,31 @@ ndsctl_json_all(FILE *fp)
 	fprintf(fp, "}\n}\n");
 
 	UNLOCK_CLIENT_LIST();
+
+	// Trusted mac list
+	if (config->trustedmaclist != NULL) {
+
+		// count the number of trusted mac addresses
+		for (trust_mac = config->trustedmaclist; trust_mac != NULL; trust_mac = trust_mac->next) {
+			count++;
+		}
+
+		// output the count of trusted macs and list them in json array format
+		fprintf(fp, "{\n\"trusted_list_length\": \"%d\",\n", count);
+		fprintf(fp, "\"trusted\":[\n");
+
+		for (trust_mac = config->trustedmaclist; trust_mac != NULL; trust_mac = trust_mac->next) {
+
+			if (count > 1) {
+				fprintf(fp, "\"%s\",\n", trust_mac->mac);
+				count--;
+			} else {
+				fprintf(fp, "\"%s\"\n", trust_mac->mac);
+			}
+		}
+
+		fprintf(fp, "]\n}\n");
+	}
 }
 
 void


### PR DESCRIPTION
ndsctl: add trusted devices list to json output.

The ndsctl json command now counts the number of trusted devices and outputs a list of them in json array format.

Some minor typos are also fixed in the config files.

Signed-off-by: Rob White `<rob@blue-wave.net>`
