### PR TITLE
Fix buffer overflow

### DIFF
--- a/src/http_microhttpd.c
+++ b/src/http_microhttpd.c
@@ -600,7 +600,9 @@ static int encode_and_redirect_to_splashpage(struct MHD_Connection *connection, 
 
 	if (originurl) {
 		if (uh_urlencode(encoded, sizeof(encoded), originurl, strlen(originurl)) == -1) {
-			debug(LOG_WARNING, "could not encode url");
+			debug(LOG_WARNING, "cannot encode url");
+			/* not enough memory */
+			return send_error(connection, 503);
 		} else {
 			debug(LOG_DEBUG, "originurl: %s", originurl);
 		}


### PR DESCRIPTION
Fix a buffer overflow for long queries.

Script to trigger

```python
#!/usr/bin/env python3

import socket 

CAPTIVE_IP = '192.168.99.3'
CAPTIVE_PORT = 2050

overflow = 'A'*30000
r = f'GET /?host=kek{overflow} HTTP/1.1\nHost: localhost\n\n'
sock = None
try:
    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    sock.connect((CAPTIVE_IP, CAPTIVE_PORT))
    sock.send(r.encode())
finally:
    if sock != None:
        sock.close()
````