### PR TITLE
state_file: remove client ID from export/import

### DIFF
--- a/src/client_list.c
+++ b/src/client_list.c
@@ -91,9 +91,6 @@ client_list_flush(void)
 	t_client *client = firstclient;
 	t_client *prev = NULL;
 
-	if (client_count == 0)
-		return;
-
 	while (client != NULL) {
 		prev = client;
 		client = client->next;

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -44,7 +44,7 @@
 
 /** Client counter */
 static int client_count = 0;
-static int client_id = 1;
+int client_id = 1;
 
 /** Global mutex to protect access to the client list */
 pthread_mutex_t client_list_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/client_list.h
+++ b/src/client_list.h
@@ -109,5 +109,6 @@ void client_list_flush(void);
 } while (0)
 
 extern pthread_mutex_t client_list_mutex;
+extern int client_id;
 
 #endif /* _NDS_CLIENT_LIST_H_ */

--- a/src/state_file.c
+++ b/src/state_file.c
@@ -15,6 +15,7 @@
 #include "debug.h"
 #include "fw_common.h"
 #include "safe.h"
+#include "fw_common.h"
 
 #define NDS_JSON_EXPORT_VERSION 1
 #define GOTO_ERR(_err, x) if ((x)) { goto _err; }
@@ -34,7 +35,6 @@ state_file_export_client(t_client *client)
 	GOTO_ERR(err, json_object_object_add(cli, "session_end", json_object_new_uint64(client->session_end)));
 	GOTO_ERR(err, json_object_object_add(cli, "download_limit", json_object_new_int64(client->download_limit)));
 	GOTO_ERR(err, json_object_object_add(cli, "upload_limit", json_object_new_int64(client->upload_limit)));
-	GOTO_ERR(err, json_object_object_add(cli, "id", json_object_new_uint64(client->id)));
 
 	json_object *counters = json_object_new_object();
 	if (!counters)
@@ -145,20 +145,13 @@ state_file_import_client(json_object *json_client)
 	t_client *client = NULL;
 	const char *mac = NULL;
 	const char *ip = NULL;
-	unsigned id;
+
 	JSON_GET_FIELD(mac, err, json_client, "mac", json_type_string, json_object_get_string);
 	JSON_GET_FIELD(ip, err, json_client, "ip", json_type_string, json_object_get_string);
-	JSON_GET_FIELD(id, err, json_client, "id", json_type_int, json_object_get_uint64);
 
 	client = client_list_find(mac, ip);
 	if (client) {
 		debug(LOG_ERR, "Found a duplicate client containing same ip & mac (%s / %s) !", ip, mac);
-		return -1;
-	}
-
-	client = client_list_find_by_id(id);
-	if (client) {
-		debug(LOG_ERR, "Found a duplicate client containing same id (%d)!", id);
 		return -1;
 	}
 
@@ -174,7 +167,6 @@ state_file_import_client(json_object *json_client)
 		free(client->token);
 
 	client->token = safe_strdup(token);
-	client->id = id;
 
 	JSON_GET_FIELD(client->session_start, err, json_client, "session_start", json_type_int, json_object_get_uint64);
 	JSON_GET_FIELD(client->session_end, err, json_client, "session_end", json_type_int, json_object_get_uint64);

--- a/src/state_file.c
+++ b/src/state_file.c
@@ -13,6 +13,7 @@
 #include "auth.h"
 #include "client_list.h"
 #include "debug.h"
+#include "fw_common.h"
 #include "safe.h"
 
 #define NDS_JSON_EXPORT_VERSION 1
@@ -186,7 +187,7 @@ state_file_import_client(json_object *json_client)
 	JSON_GET_FIELD(client->counters.outgoing, err, counters, "outgoing", json_type_int, json_object_get_uint64);
 	JSON_GET_FIELD(client->counters.last_updated, err, counters, "last_updated", json_type_int, json_object_get_uint64);
 
-	unsigned int fw_connection_state = -1;
+	unsigned int fw_connection_state = FW_MARK_PREAUTHENTICATED;
 	JSON_GET_FIELD(fw_connection_state, err, json_client, "fw_connection_state", json_type_int, json_object_get_int64);
 
 	auth_change_state(client, fw_connection_state, "import_state_file");

--- a/src/state_file.c
+++ b/src/state_file.c
@@ -13,6 +13,7 @@
 #include "auth.h"
 #include "client_list.h"
 #include "debug.h"
+#include "fw_common.h"
 #include "safe.h"
 
 #define NDS_JSON_EXPORT_VERSION 1
@@ -186,8 +187,8 @@ state_file_import_client(json_object *json_client)
 	JSON_GET_FIELD(client->counters.outgoing, err, counters, "outgoing", json_type_int, json_object_get_uint64);
 	JSON_GET_FIELD(client->counters.last_updated, err, counters, "last_updated", json_type_int, json_object_get_uint64);
 
-	unsigned int fw_connection_state = -1;
-	JSON_GET_FIELD(fw_connection_state, err, json_client, "fw_connection_state", json_type_int, json_object_get_int64);
+	unsigned int fw_connection_state = FW_MARK_PREAUTHENTICATED;
+	JSON_GET_FIELD(fw_connection_state, err, json_client, "fw_connection_state", json_type_int, json_object_get_int);
 
 	auth_change_state(client, fw_connection_state, "import_state_file");
 

--- a/tests/state_file/Makefile
+++ b/tests/state_file/Makefile
@@ -3,6 +3,7 @@ CC?=gcc
 CFLAGS?=-O2 -g -Wall
 CFLAGS+=-I../../src
 CFLAGS+= -DWITH_STATE_FILE
+CFLAGS+= -D__NDS_UNIT_TEST
 
 LDLIBS+=-ljson-c
 

--- a/tests/state_file/test_state_file.c
+++ b/tests/state_file/test_state_file.c
@@ -116,6 +116,7 @@ void one_client(void)
 {
 	assert(state_file_import("one_client.json") == 0);
 	assert(get_client_list_length() == 1);
+	assert(get_client_list_length() + 1 == client_id);
 	t_client *client = client_get_first_client();
 	validate_client_b(client);
 }
@@ -141,6 +142,7 @@ void three_clients(void)
 	print_client_list();
 
 	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 	t_client *client = client_get_first_client();
 	validate_client_a(client);
 
@@ -156,6 +158,7 @@ void three_clients_dup_id(void)
 	/* client IDs are ignored on import, resulting in 3 valid clients */
 	assert(state_file_import("three_clients_dup_id.json") == 0);
 	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 	print_client_list();
 }
 
@@ -165,6 +168,7 @@ void three_clients_dup_mac(void)
 	assert(state_file_import("three_clients_dup_mac.json") == 0);
 	print_client_list();
 	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 }
 
 void three_clients_dup_ip(void)
@@ -173,6 +177,7 @@ void three_clients_dup_ip(void)
 	assert(state_file_import("three_clients_dup_ip.json") == 0);
 	print_client_list();
 	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 }
 
 struct a_test {

--- a/tests/state_file/test_state_file.c
+++ b/tests/state_file/test_state_file.c
@@ -63,7 +63,6 @@ void validate_client_a(t_client *client)
 	assert(!strcmp(client->mac, "00:16:3e:d8:29:6e"));
 	assert(!strcmp(client->ip, "192.168.42.222"));
 	assert(!strcmp(client->token, "fb843328"));
-	assert(client->id == 1);
 	assert(client->counters.last_updated == 1756220171);
 	assert(client->counters.incoming == 1586);
 	assert(client->counters.outgoing == 918);
@@ -75,7 +74,6 @@ void validate_client_b(t_client *client)
 	assert(!strcmp(client->mac, "00:16:3e:06:e3:7c"));
 	assert(!strcmp(client->ip, "192.168.42.44"));
 	assert(!strcmp(client->token, "49c1fb0e"));
-	assert(client->id == 2);
 	assert(client->counters.last_updated == 1756220222);
 	assert(client->counters.incoming == 6890102);
 	assert(client->counters.outgoing == 113871);
@@ -87,7 +85,6 @@ void validate_client_c(t_client *client)
 	assert(!strcmp(client->mac, "00:16:3e:06:ea:aa"));
 	assert(!strcmp(client->ip, "192.168.42.42"));
 	assert(!strcmp(client->token, "13523b0e"));
-	assert(client->id == 3);
 	assert(client->counters.last_updated == 1756220222);
 	assert(client->counters.incoming == 6890102);
 	assert(client->counters.outgoing == 113871);
@@ -119,6 +116,7 @@ void one_client(void)
 {
 	assert(state_file_import("one_client.json") == 0);
 	assert(get_client_list_length() == 1);
+	assert(get_client_list_length() + 1 == client_id);
 	t_client *client = client_get_first_client();
 	validate_client_b(client);
 }
@@ -144,6 +142,7 @@ void three_clients(void)
 	print_client_list();
 
 	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 	t_client *client = client_get_first_client();
 	validate_client_a(client);
 
@@ -156,9 +155,10 @@ void three_clients(void)
 
 void three_clients_dup_id(void)
 {
-	/* invalid entries are ignored, 2 valid entries, 1 invalid */
+	/* client IDs are ignored on import, resulting in 3 valid clients */
 	assert(state_file_import("three_clients_dup_id.json") == 0);
-	assert(get_client_list_length() == 2);
+	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 	print_client_list();
 }
 
@@ -168,6 +168,7 @@ void three_clients_dup_mac(void)
 	assert(state_file_import("three_clients_dup_mac.json") == 0);
 	print_client_list();
 	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 }
 
 void three_clients_dup_ip(void)
@@ -176,6 +177,7 @@ void three_clients_dup_ip(void)
 	assert(state_file_import("three_clients_dup_ip.json") == 0);
 	print_client_list();
 	assert(get_client_list_length() == 3);
+	assert(get_client_list_length() + 1 == client_id);
 }
 
 struct a_test {

--- a/tests/state_file/test_state_file.c
+++ b/tests/state_file/test_state_file.c
@@ -63,7 +63,6 @@ void validate_client_a(t_client *client)
 	assert(!strcmp(client->mac, "00:16:3e:d8:29:6e"));
 	assert(!strcmp(client->ip, "192.168.42.222"));
 	assert(!strcmp(client->token, "fb843328"));
-	assert(client->id == 1);
 	assert(client->counters.last_updated == 1756220171);
 	assert(client->counters.incoming == 1586);
 	assert(client->counters.outgoing == 918);
@@ -75,7 +74,6 @@ void validate_client_b(t_client *client)
 	assert(!strcmp(client->mac, "00:16:3e:06:e3:7c"));
 	assert(!strcmp(client->ip, "192.168.42.44"));
 	assert(!strcmp(client->token, "49c1fb0e"));
-	assert(client->id == 2);
 	assert(client->counters.last_updated == 1756220222);
 	assert(client->counters.incoming == 6890102);
 	assert(client->counters.outgoing == 113871);
@@ -87,7 +85,6 @@ void validate_client_c(t_client *client)
 	assert(!strcmp(client->mac, "00:16:3e:06:ea:aa"));
 	assert(!strcmp(client->ip, "192.168.42.42"));
 	assert(!strcmp(client->token, "13523b0e"));
-	assert(client->id == 3);
 	assert(client->counters.last_updated == 1756220222);
 	assert(client->counters.incoming == 6890102);
 	assert(client->counters.outgoing == 113871);
@@ -156,9 +153,9 @@ void three_clients(void)
 
 void three_clients_dup_id(void)
 {
-	/* invalid entries are ignored, 2 valid entries, 1 invalid */
+	/* client IDs are ignored on import, resulting in 3 valid clients */
 	assert(state_file_import("three_clients_dup_id.json") == 0);
-	assert(get_client_list_length() == 2);
+	assert(get_client_list_length() == 3);
 	print_client_list();
 }
 


### PR DESCRIPTION
Let client_list_add_client() assign IDs automatically to prevent duplicate IDs after state file restore. Also fix fw_connection_state to use json_object_get_int instead of json_object_get_int64."